### PR TITLE
Show which patch is giving "bad patch" error

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1654,6 +1654,7 @@ static void AM_drawMarks (void)
 {
     int i, fx, fy;
     mpoint_t pt;
+    char name[9];
 
     for ( i = 0 ; i < AM_NUMMARKPOINTS ; i++)
     {
@@ -1673,7 +1674,9 @@ static void AM_drawMarks (void)
 
             if (fx >= f_x && fx <= f_w - 5 && fy >= f_y && fy <= f_h - 6)
             {
-                V_DrawPatch(fx, fy, marknums[i]);
+                // [JN] Construct proper patch name for possible error handling:
+                sprintf(name, "AMMNUM%d", i);
+                V_DrawPatch(fx, fy, marknums[i], name);
             }
         }
     }

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -585,7 +585,7 @@ void D_PageTicker (void)
 
 void D_PageDrawer (void)
 {
-    V_DrawPatch (0, 0, W_CacheLumpName(pagename, PU_CACHE));
+    V_DrawPatch (0, 0, W_CacheLumpName(pagename, PU_CACHE), pagename);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -311,6 +311,8 @@ static void D_Display (void)
     // draw pause pic
     if (paused)
     {
+        char *m_pause = DEH_String("M_PAUSE");
+
         if (automapactive)
         {
             y = 4;
@@ -321,7 +323,7 @@ static void D_Display (void)
         }
 
         V_DrawShadowedPatch(viewwindowx + (scaledviewwidth - 68) / 2, y,
-                            W_CacheLumpName (DEH_String("M_PAUSE"), PU_CACHE));
+                            W_CacheLumpName (m_pause, PU_CACHE), m_pause);
     }
 
     // [JN] Do not draw any CRL widgets if not in game level.
@@ -373,11 +375,13 @@ static void D_Display (void)
 
     // Handle player messages
     CRL_DrawMessage();
-    CRL_DrawCriticalMessage();
 
     // menus go directly to the screen
     M_Drawer ();   // menu is drawn even on top of everything
     NetUpdate ();  // send out any new accumulation
+
+    // [JN] Critical messages are drawn even higher than on top everything!
+    CRL_DrawCriticalMessage();
 
     // normal update
     if (!wipe)

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -358,6 +358,7 @@ void F_TextWrite (void)
     int		c;
     int		cx;
     int		cy;
+    char	name[9];
     
     // erase the entire screen to a tiled background
     src = W_CacheLumpName ( finaleflat , PU_CACHE);
@@ -409,7 +410,9 @@ void F_TextWrite (void)
 	w = SHORT (hu_font[c]->width);
 	if (cx+w > SCREENWIDTH)
 	    break;
-	V_DrawShadowedPatch(cx, cy, hu_font[c]);
+	// [JN] Construct proper patch name for possible error handling:
+	sprintf(name, "STCFN%03d", c + HU_FONTSTART);
+	V_DrawShadowedPatch(cx, cy, hu_font[c], name);
 	cx+=w;
     }
 	

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -620,9 +620,10 @@ void F_CastDrawer (void)
     int			lump;
     boolean		flip;
     patch_t*		patch;
+    char *bossback = DEH_String("BOSSBACK");
     
     // erase the entire screen to a background
-    V_DrawPatch (0, 0, W_CacheLumpName (DEH_String("BOSSBACK"), PU_CACHE));
+    V_DrawPatch (0, 0, W_CacheLumpName (bossback, PU_CACHE), bossback);
 
     // [JN] Simplify to use common text drawing function.
     M_WriteTextCentered(180, DEH_String(castorder[castnum].name), NULL);
@@ -637,7 +638,8 @@ void F_CastDrawer (void)
     if (flip)
 	V_DrawPatchFlipped(SCREENWIDTH/2, 170, patch);
     else
-	V_DrawPatch(SCREENWIDTH/2, 170, patch);
+    // [JN] TODO - handle "bad v_drawpatch" name. But how?
+	V_DrawPatch(SCREENWIDTH/2, 170, patch, "NULL");
 }
 
 
@@ -688,6 +690,7 @@ void F_BunnyScroll (void)
     char	name[10];
     int		stage;
     static int	laststage;
+    char	*end0 = DEH_String("END0");
 		
     p1 = W_CacheLumpName (DEH_String("PFUB2"), PU_LEVEL);
     p2 = W_CacheLumpName (DEH_String("PFUB1"), PU_LEVEL);
@@ -714,7 +717,7 @@ void F_BunnyScroll (void)
     {
         V_DrawPatch((SCREENWIDTH - 13 * 8) / 2,
                     (SCREENHEIGHT - 8 * 8) / 2, 
-                     W_CacheLumpName(DEH_String("END0"), PU_CACHE));
+                     W_CacheLumpName(end0, PU_CACHE), end0);
 	laststage = 0;
 	return;
     }
@@ -731,7 +734,7 @@ void F_BunnyScroll (void)
     DEH_snprintf(name, 10, "END%i", stage);
     V_DrawPatch((SCREENWIDTH - 13 * 8) / 2, 
                 (SCREENHEIGHT - 8 * 8) / 2, 
-                W_CacheLumpName (name,PU_CACHE));
+                W_CacheLumpName (name,PU_CACHE), name);
 }
 
 static void F_ArtScreenDrawer(void)
@@ -768,7 +771,7 @@ static void F_ArtScreenDrawer(void)
 
         lumpname = DEH_String(lumpname);
 
-        V_DrawPatch (0, 0, W_CacheLumpName(lumpname, PU_CACHE));
+        V_DrawPatch (0, 0, W_CacheLumpName(lumpname, PU_CACHE), lumpname);
     }
 }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1531,8 +1531,9 @@ static void M_ReadSaveStrings(void)
 static void M_DrawLoad(void)
 {
     int             i;
+    char *m_loadg = DEH_String("M_LOADG");
 	
-    V_DrawShadowedPatch(72, 12, W_CacheLumpName(DEH_String("M_LOADG"), PU_CACHE));
+    V_DrawShadowedPatch(72, 12, W_CacheLumpName(m_loadg, PU_CACHE), m_loadg);
 
     for (i = 0;i < load_end; i++)
     {
@@ -1549,16 +1550,19 @@ static void M_DrawLoad(void)
 static void M_DrawSaveLoadBorder(int x,int y)
 {
     int             i;
+    char *m_lsleft = DEH_String("M_LSLEFT");
+    char *m_lscntr = DEH_String("M_LSCNTR");
+    char *m_lsrght = DEH_String("M_LSRGHT");
 	
-    V_DrawShadowedPatch(x - 8, y + 7, W_CacheLumpName(DEH_String("M_LSLEFT"), PU_CACHE));
+    V_DrawShadowedPatch(x - 8, y + 7, W_CacheLumpName(m_lsleft, PU_CACHE), m_lsleft);
 	
     for (i = 0;i < 24;i++)
     {
-	V_DrawShadowedPatch(x, y + 7, W_CacheLumpName(DEH_String("M_LSCNTR"), PU_CACHE));
+	V_DrawShadowedPatch(x, y + 7, W_CacheLumpName(m_lscntr, PU_CACHE), m_lscntr);
 	x += 8;
     }
 
-    V_DrawShadowedPatch(x, y + 7, W_CacheLumpName(DEH_String("M_LSRGHT"), PU_CACHE));
+    V_DrawShadowedPatch(x, y + 7, W_CacheLumpName(m_lsrght, PU_CACHE),m_lsrght);
 }
 
 
@@ -1599,8 +1603,9 @@ static void M_LoadGame (int choice)
 static void M_DrawSave(void)
 {
     int             i;
+    char *m_saveg = DEH_String("M_SAVEG");
 	
-    V_DrawShadowedPatch(72, 12, W_CacheLumpName(DEH_String("M_SAVEG"), PU_CACHE));
+    V_DrawShadowedPatch(72, 12, W_CacheLumpName(m_saveg, PU_CACHE), m_saveg);
     for (i = 0;i < load_end; i++)
     {
 	M_DrawSaveLoadBorder(LoadDef.x,LoadDef.y+LINEHEIGHT*i);
@@ -1776,7 +1781,9 @@ static void M_DrawReadThisCommercial(void)
 //
 static void M_DrawSound(void)
 {
-    V_DrawShadowedPatch(60, 38, W_CacheLumpName(DEH_String("M_SVOL"), PU_CACHE));
+    char *m_svol = DEH_String("M_SVOL");
+
+    V_DrawShadowedPatch(60, 38, W_CacheLumpName(m_svol, PU_CACHE), m_svol);
 
     M_DrawThermo(SoundDef.x,SoundDef.y+LINEHEIGHT*(sfx_vol+1),
 		 16,sfxVolume);
@@ -1843,8 +1850,11 @@ static void M_DrawMainMenu(void)
 //
 static void M_DrawNewGame(void)
 {
-    V_DrawShadowedPatch(96, 14, W_CacheLumpName(DEH_String("M_NEWG"), PU_CACHE));
-    V_DrawShadowedPatch(54, 38, W_CacheLumpName(DEH_String("M_SKILL"), PU_CACHE));
+    char *m_newg = DEH_String("M_NEWG");
+    char *m_skill = DEH_String("M_SKILL");
+
+    V_DrawShadowedPatch(96, 14, W_CacheLumpName(m_newg, PU_CACHE), m_newg);
+    V_DrawShadowedPatch(54, 38, W_CacheLumpName(m_skill, PU_CACHE), m_skill);
 }
 
 static void M_NewGame(int choice)
@@ -1871,7 +1881,9 @@ static int epi;
 
 static void M_DrawEpisode(void)
 {
-    V_DrawShadowedPatch(54, 38, W_CacheLumpName(DEH_String("M_EPISOD"), PU_CACHE));
+    char *m_episod = DEH_String("M_EPISOD");
+
+    V_DrawShadowedPatch(54, 38, W_CacheLumpName(m_episod, PU_CACHE), m_episod);
 }
 
 static void M_VerifyNightmare(int key)
@@ -1919,13 +1931,17 @@ static char *msgNames[2] = {"M_MSGOFF","M_MSGON"};
 
 static void M_DrawOptions(void)
 {
-    V_DrawShadowedPatch(108, 15, W_CacheLumpName(DEH_String("M_OPTTTL"), PU_CACHE));
+    char *m_optttl = DEH_String("M_OPTTTL");
+
+    V_DrawShadowedPatch(108, 15, W_CacheLumpName(m_optttl, PU_CACHE), m_optttl);
 	
     V_DrawShadowedPatch(OptionsDef.x + 175, OptionsDef.y + LINEHEIGHT * detail,
-		        W_CacheLumpName(DEH_String(detailNames[detailLevel]), PU_CACHE));
+		        W_CacheLumpName(DEH_String(detailNames[detailLevel]), PU_CACHE),
+                                DEH_String(detailNames[detailLevel]));
 
     V_DrawShadowedPatch(OptionsDef.x + 120, OptionsDef.y + LINEHEIGHT * messages,
-                W_CacheLumpName(DEH_String(msgNames[showMessages]), PU_CACHE));
+                W_CacheLumpName(DEH_String(msgNames[showMessages]), PU_CACHE),
+                                DEH_String(msgNames[showMessages]));
 
     M_DrawThermo(OptionsDef.x, OptionsDef.y + LINEHEIGHT * (mousesens + 1),
 		 10, mouseSensitivity);
@@ -2165,16 +2181,20 @@ M_DrawThermo
 {
     int		xx;
     int		i;
+    char	*m_therml = DEH_String("M_THERML");
+    char	*m_thermm = DEH_String("M_THERMM");
+    char	*m_thermr = DEH_String("M_THERMR");
+    char	*m_thermo = DEH_String("M_THERMO");
 
     xx = x;
-    V_DrawShadowedPatch(xx, y, W_CacheLumpName(DEH_String("M_THERML"), PU_CACHE));
+    V_DrawShadowedPatch(xx, y, W_CacheLumpName(m_therml, PU_CACHE), m_therml);
     xx += 8;
     for (i=0;i<thermWidth;i++)
     {
-	V_DrawShadowedPatch(xx, y, W_CacheLumpName(DEH_String("M_THERMM"), PU_CACHE));
+	V_DrawShadowedPatch(xx, y, W_CacheLumpName(m_thermm, PU_CACHE), m_thermm);
 	xx += 8;
     }
-    V_DrawShadowedPatch(xx, y, W_CacheLumpName(DEH_String("M_THERMR"), PU_CACHE));
+    V_DrawShadowedPatch(xx, y, W_CacheLumpName(m_thermr, PU_CACHE), m_thermr);
 
     // [crispy] do not crash anymore if value exceeds thermometer range
     if (thermDot >= thermWidth)
@@ -2182,7 +2202,7 @@ M_DrawThermo
         thermDot = thermWidth - 1;
     }
 
-    V_DrawPatch((x + 8) + thermDot * 8, y, W_CacheLumpName(DEH_String("M_THERMO"), PU_CACHE));
+    V_DrawPatch((x + 8) + thermDot * 8, y, W_CacheLumpName(m_thermo, PU_CACHE));
 }
 
 static void
@@ -2250,6 +2270,7 @@ void M_WriteText (int x, int y, const char *string, byte *table)
 {
     const char*	ch;
     int w, c, cx, cy;
+    char name[9];
 
     ch = string;
     cx = x;
@@ -2298,7 +2319,9 @@ void M_WriteText (int x, int y, const char *string, byte *table)
             break;
         }
 
-        V_DrawShadowedPatch(cx, cy, hu_font[c]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STCFN%03d", c + HU_FONTSTART);
+        V_DrawShadowedPatch(cx, cy, hu_font[c], name);
         cx+=w;
     }
 
@@ -2315,6 +2338,7 @@ void M_WriteTextCentered (const int y, const char *string, byte *table)
     const char *ch;
     const int width = M_StringWidth(string);
     int w, c, cx, cy;
+    char name[9];
 
     ch = string;
     cx = SCREENWIDTH/2-width/2;
@@ -2370,7 +2394,9 @@ void M_WriteTextCentered (const int y, const char *string, byte *table)
             break;
         }
         
-        V_DrawShadowedPatch(cx, cy, hu_font[c]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STCFN%03d", c + HU_FONTSTART);
+        V_DrawShadowedPatch(cx, cy, hu_font[c], name);
         cx += w;
     }
     
@@ -3232,7 +3258,7 @@ void M_Drawer (void)
         {
             if (name[0])
             {
-                V_DrawShadowedPatch(x, y, W_CacheLumpName(name, PU_CACHE));
+                V_DrawShadowedPatch(x, y, W_CacheLumpName(name, PU_CACHE), name);
             }
             y += LINEHEIGHT;
         }
@@ -3247,7 +3273,8 @@ void M_Drawer (void)
     {
         // DRAW SKULL
         V_DrawShadowedPatch(x + SKULLXOFF, currentMenu->y - 5 + itemOn*LINEHEIGHT,
-	    	        W_CacheLumpName(DEH_String(skullName[whichSkull]), PU_CACHE));
+                            W_CacheLumpName(DEH_String(skullName[whichSkull]), PU_CACHE),
+                            DEH_String(skullName[whichSkull]));
     }
 }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1754,7 +1754,9 @@ static void M_QuickLoad(void)
 //
 static void M_DrawReadThis1(void)
 {
-    V_DrawPatch(0, 0, W_CacheLumpName(DEH_String("HELP2"), PU_CACHE));
+    char *help2 = DEH_String("HELP2");
+
+    V_DrawPatch(0, 0, W_CacheLumpName(help2, PU_CACHE), help2);
 }
 
 
@@ -1764,15 +1766,19 @@ static void M_DrawReadThis1(void)
 //
 static void M_DrawReadThis2(void)
 {
+    char *help1 = DEH_String("HELP1");
+
     // We only ever draw the second page if this is 
     // gameversion == exe_doom_1_9 and gamemode == registered
 
-    V_DrawPatch(0, 0, W_CacheLumpName(DEH_String("HELP1"), PU_CACHE));
+    V_DrawPatch(0, 0, W_CacheLumpName(help1, PU_CACHE), help1);
 }
 
 static void M_DrawReadThisCommercial(void)
 {
-    V_DrawPatch(0, 0, W_CacheLumpName(DEH_String("HELP"), PU_CACHE));
+    char *help = DEH_String("HELP");
+
+    V_DrawPatch(0, 0, W_CacheLumpName(help, PU_CACHE), help);
 }
 
 
@@ -1839,7 +1845,9 @@ static void M_MusicVol(int choice)
 //
 static void M_DrawMainMenu(void)
 {
-    V_DrawPatch(94, 2, W_CacheLumpName(DEH_String("M_DOOM"), PU_CACHE));
+    char *m_doom = DEH_String("M_DOOM");
+
+    V_DrawPatch(94, 2, W_CacheLumpName(m_doom, PU_CACHE), m_doom);
 }
 
 
@@ -2202,7 +2210,7 @@ M_DrawThermo
         thermDot = thermWidth - 1;
     }
 
-    V_DrawPatch((x + 8) + thermDot * 8, y, W_CacheLumpName(m_thermo, PU_CACHE));
+    V_DrawPatch((x + 8) + thermDot * 8, y, W_CacheLumpName(m_thermo, PU_CACHE), m_thermo);
 }
 
 static void

--- a/src/doom/r_draw.c
+++ b/src/doom/r_draw.c
@@ -747,6 +747,16 @@ void R_FillBackScreen (void)
 
     char *name;
 
+    char *brdr_t = DEH_String("brdr_t");
+    char *brdr_b = DEH_String("brdr_b");
+    char *brdr_l = DEH_String("brdr_l");
+    char *brdr_r = DEH_String("brdr_r");
+
+    char *brdr_tl = DEH_String("brdr_tl");
+    char *brdr_tr = DEH_String("brdr_tr");
+    char *brdr_bl = DEH_String("brdr_bl");
+    char *brdr_br = DEH_String("brdr_br");
+
     // If we are running full screen, there is no need to do any of this,
     // and the background buffer can be freed if it was previously in use.
 
@@ -796,39 +806,39 @@ void R_FillBackScreen (void)
 
     V_UseBuffer(background_buffer);
 
-    patch = W_CacheLumpName(DEH_String("brdr_t"),PU_CACHE);
+    patch = W_CacheLumpName(brdr_t,PU_CACHE);
 
     for (x=0 ; x<scaledviewwidth ; x+=8)
-	V_DrawPatch(viewwindowx+x, viewwindowy-8, patch);
-    patch = W_CacheLumpName(DEH_String("brdr_b"),PU_CACHE);
+	V_DrawPatch(viewwindowx+x, viewwindowy-8, patch, brdr_t);
+    patch = W_CacheLumpName(brdr_b,PU_CACHE);
 
     for (x=0 ; x<scaledviewwidth ; x+=8)
-	V_DrawPatch(viewwindowx+x, viewwindowy+viewheight, patch);
-    patch = W_CacheLumpName(DEH_String("brdr_l"),PU_CACHE);
+	V_DrawPatch(viewwindowx+x, viewwindowy+viewheight, patch, brdr_b);
+    patch = W_CacheLumpName(brdr_l,PU_CACHE);
 
     for (y=0 ; y<viewheight ; y+=8)
-	V_DrawPatch(viewwindowx-8, viewwindowy+y, patch);
-    patch = W_CacheLumpName(DEH_String("brdr_r"),PU_CACHE);
+	V_DrawPatch(viewwindowx-8, viewwindowy+y, patch, brdr_l);
+    patch = W_CacheLumpName(brdr_r,PU_CACHE);
 
     for (y=0 ; y<viewheight ; y+=8)
-	V_DrawPatch(viewwindowx+scaledviewwidth, viewwindowy+y, patch);
+	V_DrawPatch(viewwindowx+scaledviewwidth, viewwindowy+y, patch, brdr_r);
 
     // Draw beveled edge. 
     V_DrawPatch(viewwindowx-8,
                 viewwindowy-8,
-                W_CacheLumpName(DEH_String("brdr_tl"),PU_CACHE));
+                W_CacheLumpName(brdr_tl,PU_CACHE), brdr_tl);
     
     V_DrawPatch(viewwindowx+scaledviewwidth,
                 viewwindowy-8,
-                W_CacheLumpName(DEH_String("brdr_tr"),PU_CACHE));
+                W_CacheLumpName(brdr_tr,PU_CACHE), brdr_tr);
     
     V_DrawPatch(viewwindowx-8,
                 viewwindowy+viewheight,
-                W_CacheLumpName(DEH_String("brdr_bl"),PU_CACHE));
+                W_CacheLumpName(brdr_bl,PU_CACHE), brdr_bl);
     
     V_DrawPatch(viewwindowx+scaledviewwidth,
                 viewwindowy+viewheight,
-                W_CacheLumpName(DEH_String("brdr_br"),PU_CACHE));
+                W_CacheLumpName(brdr_br,PU_CACHE), brdr_br);
 
     V_RestoreBuffer();
 } 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -142,6 +142,32 @@ cheatseq_t cheat_powerup[7] =
     CHEAT("idbehold", 0),
 };
 
+// [JN] Patch names used for possible error handling in V_DrawPatch.
+// Just line in IWAD, they are numbered by st_faceindex num.
+static char *facenames[] =
+{
+    "STFST00", "STFST01", "STFST02",   // 0, 1, 2
+    "STFTR00", "STFTL00", "STFOUCH0",  // 3, 4, 5
+    "STFEVL0", "STFKILL0",             // 6, 7
+
+    "STFST10", "STFST11", "STFST12",   // 8, 9, 10
+    "STFTR10", "STFTL10", "STFOUCH1",  // 11, 12, 13
+    "STFEVL1", "STFKILL1",             // 14, 15
+
+    "STFST20", "STFST21", "STFST22",   // 16, 17, 18
+    "STFTR20", "STFTL20", "STFOUCH2",  // 19, 20, 21
+    "STFEVL2", "STFKILL2",             // 22, 23
+
+    "STFST30", "STFST31", "STFST32",   // 24, 25, 26
+    "STFTR30", "STFTL30", "STFOUCH3",  // 27, 28, 29
+    "STFEVL3", "STFKILL3",             // 30, 31
+
+    "STFST40", "STFST41", "STFST42",   // 32, 33, 34
+    "STFTR40", "STFTL40", "STFOUCH4",  // 35, 36, 37
+    "STFEVL4", "STFKILL4",             // 38, 39
+
+    "STFGOD0", "STFDEAD0"              // 40, 41
+};
 
 // -----------------------------------------------------------------------------
 // GiveBackpack
@@ -984,6 +1010,7 @@ static void ST_DrawBigNumber (int val, const int x, const int y, byte *table)
 {
     int oldval = val;
     int xpos = x;
+    char name[9];
 
     dp_translation = table;
 
@@ -999,7 +1026,7 @@ static void ST_DrawBigNumber (int val, const int x, const int y, byte *table)
 
         // [JN] Draw minus symbol with respection of digits placement.
         // However, values below -10 requires some correction in "x" placement.
-        V_DrawPatch(xpos + (val <= 9 ? 20 : 5) - 4, y, tallminus);
+        V_DrawPatch(xpos + (val <= 9 ? 20 : 5) - 4, y, tallminus, DEH_String("STTMINUS"));
     }
     if (val > 999)
     {
@@ -1008,7 +1035,9 @@ static void ST_DrawBigNumber (int val, const int x, const int y, byte *table)
 
     if (val > 99)
     {
-        V_DrawPatch(xpos - 4, y, tallnum[val / 100]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STTNUM%d", val/100);
+        V_DrawPatch(xpos - 4, y, tallnum[val / 100], name);
     }
 
     val = val % 100;
@@ -1016,13 +1045,17 @@ static void ST_DrawBigNumber (int val, const int x, const int y, byte *table)
 
     if (val > 9 || oldval > 99)
     {
-        V_DrawPatch(xpos - 4, y, tallnum[val / 10]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STTNUM%d", val/10);
+        V_DrawPatch(xpos - 4, y, tallnum[val / 10], name);
     }
 
     val = val % 10;
     xpos += 14;
 
-    V_DrawPatch(xpos - 4, y, tallnum[val]);
+    // [JN] Construct proper patch name for possible error handling:
+    sprintf(name, "STTNUM%d", val);
+    V_DrawPatch(xpos - 4, y, tallnum[val], name);
     
     dp_translation = NULL;
 }
@@ -1035,7 +1068,7 @@ static void ST_DrawBigNumber (int val, const int x, const int y, byte *table)
 static void ST_DrawPercent (const int x, const int y, byte *table)
 {
     dp_translation = table;
-    V_DrawPatch(x, y, tallpercent);
+    V_DrawPatch(x, y, tallpercent, DEH_String("STTPRCNT"));
     dp_translation = NULL;
 }
 
@@ -1048,6 +1081,7 @@ static void ST_DrawSmallNumberY (int val, const int x, const int y)
 {
     int oldval = val;
     int xpos = x;
+    char name[9];
 
     if (val < 0)
     {
@@ -1060,7 +1094,9 @@ static void ST_DrawSmallNumberY (int val, const int x, const int y)
 
     if (val > 99)
     {
-        V_DrawPatch(xpos - 4, y, shortnum_y[val / 100]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STYSNUM%d", val/100);
+        V_DrawPatch(xpos - 4, y, shortnum_y[val / 100], name);
     }
 
     val = val % 100;
@@ -1068,13 +1104,17 @@ static void ST_DrawSmallNumberY (int val, const int x, const int y)
 
     if (val > 9 || oldval > 99)
     {
-        V_DrawPatch(xpos - 4, y, shortnum_y[val / 10]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STYSNUM%d", val/10);
+        V_DrawPatch(xpos - 4, y, shortnum_y[val / 10], name);
     }
 
     val = val % 10;
     xpos += 4;
 
-    V_DrawPatch(xpos - 4, y, shortnum_y[val]);
+    // [JN] Construct proper patch name for possible error handling:
+    sprintf(name, "STYSNUM%d", val);
+    V_DrawPatch(xpos - 4, y, shortnum_y[val], name);
 }
 
 // -----------------------------------------------------------------------------
@@ -1084,6 +1124,8 @@ static void ST_DrawSmallNumberY (int val, const int x, const int y)
 
 static void ST_DrawSmallNumberG (int val, const int x, const int y)
 {
+    char name[9];
+
     if (val < 0)
     {
         val = 0;
@@ -1093,7 +1135,9 @@ static void ST_DrawSmallNumberG (int val, const int x, const int y)
         val = 9;
     }
 
-    V_DrawPatch(x + 4, y, shortnum_g[val]);
+    // [JN] Construct proper patch name for possible error handling:
+    sprintf(name, "STGNUM%d", val);
+    V_DrawPatch(x + 4, y, shortnum_g[val], name);
 }
 
 // -----------------------------------------------------------------------------
@@ -1114,19 +1158,23 @@ static void ST_DrawWeaponNumberFunc (const int val, const int x, const int y, co
 
 void ST_Drawer (void)
 {
+    char  name[9];
+    char *facename;
     plyr = &players[displayplayer];
 
     // Status bar background.
     if (crl_screen_size <= 10 || (automapactive && !crl_automap_overlay))
     {
         V_UseBuffer(st_backing_screen);
-        V_DrawPatch(0, 0, sbar);
+        V_DrawPatch(0, 0, sbar, DEH_String("STBAR"));
 
         if (netgame)
         {
             // Player face background
+            // [JN] Construct proper patch name for possible error handling:
+            sprintf(name, "STFB%d", displayplayer);
             // [JN] killough 3/7/98: make face background change with displayplayer
-            V_DrawPatch(143, 0, faceback[displayplayer]);
+            V_DrawPatch(143, 0, faceback[displayplayer], name);
         }
 
         V_RestoreBuffer();
@@ -1135,7 +1183,7 @@ void ST_Drawer (void)
         // ARMS background
         if (!deathmatch)
         {
-            V_DrawPatch(104, 168, armsbg);
+            V_DrawPatch(104, 168, armsbg, DEH_String("STARMS"));
         }
     }
 
@@ -1177,12 +1225,16 @@ void ST_Drawer (void)
     // Player face background
     if (crl_screen_size == 11)
     {
-        V_DrawPatch(143, 169, netgame ? faceback[displayplayer] : faceback[1]);
+        // [JN] Construct proper patch name for possible error handling:
+        sprintf(name, "STFB%d", netgame ? displayplayer : 1);
+        V_DrawPatch(143, 169, netgame ? faceback[displayplayer] : faceback[1], name);
     }
     // Player face
     if (crl_screen_size <= 11 || (automapactive && !crl_automap_overlay))
     {
-        V_DrawPatch(143, 168, faces[st_faceindex]);
+        // [JN] Construct proper patch name for possible error handling:
+        facename = facenames[st_faceindex];
+        V_DrawPatch(143, 168, faces[st_faceindex], facename);
     }
 
     // Armor
@@ -1191,19 +1243,19 @@ void ST_Drawer (void)
 
     // Keys
     if (plyr->cards[it_blueskull])
-    V_DrawPatch(239, 171, keys[3]);
+    V_DrawPatch(239, 171, keys[3], DEH_String("STKEYS3"));
     else if (plyr->cards[it_bluecard])
-    V_DrawPatch(239, 171, keys[0]);
+    V_DrawPatch(239, 171, keys[0], DEH_String("STKEYS0"));
 
     if (plyr->cards[it_yellowskull])
-    V_DrawPatch(239, 181, keys[4]);
+    V_DrawPatch(239, 181, keys[4], DEH_String("STKEYS4"));
     else if (plyr->cards[it_yellowcard])
-    V_DrawPatch(239, 181, keys[1]);
+    V_DrawPatch(239, 181, keys[1], DEH_String("STKEYS1"));
 
     if (plyr->cards[it_redskull])
-    V_DrawPatch(239, 191, keys[5]);
+    V_DrawPatch(239, 191, keys[5], DEH_String("STKEYS5"));
     else if (plyr->cards[it_redcard])
-    V_DrawPatch(239, 191, keys[2]);
+    V_DrawPatch(239, 191, keys[2], DEH_String("STKEYS2"));
 
     // Ammo (current)
     ST_DrawSmallNumberY(plyr->ammo[0], 280, 173);

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -1319,6 +1319,7 @@ void WI_drawNetgameStats(void)
     int		x;
     int		y;
     int		pwidth = SHORT(percent->width);
+    char	name[9];
 
     WI_slamBackground();
     

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -421,17 +421,28 @@ boolean WI_Responder(event_t* ev)
 void WI_drawLF(void)
 {
     int y = WI_TITLEY;
+    char lvlname[9];
 
     if (gamemode != commercial || wbs->last < NUMCMAPS)
     {
+        // [JN] Construct proper patch name for possible error handling:
+        if (gamemode == commercial)
+        {
+            sprintf(lvlname, "CWILV%2.2d", wbs->last);
+        }
+        else
+        {
+            sprintf(lvlname, "WILV%d%d", wbs->epsd, wbs->last);
+        }
+
         // draw <LevelName> 
         V_DrawShadowedPatch((SCREENWIDTH - SHORT(lnames[wbs->last]->width))/2,
-                    y, lnames[wbs->last]);
+                    y, lnames[wbs->last], lvlname);
 
         // draw "Finished!"
         y += (5*SHORT(lnames[wbs->last]->height))/4;
 
-        V_DrawShadowedPatch((SCREENWIDTH - SHORT(finished->width)) / 2, y, finished);
+        V_DrawShadowedPatch((SCREENWIDTH - SHORT(finished->width)) / 2, y, finished, DEH_String("WIF"));
     }
     else if (wbs->last == NUMCMAPS)
     {
@@ -457,18 +468,29 @@ void WI_drawLF(void)
 void WI_drawEL(void)
 {
     int y = WI_TITLEY;
+    char lvlname[9];
 
     // draw "Entering"
     V_DrawShadowedPatch((SCREENWIDTH - SHORT(entering->width))/2,
 		y,
-                entering);
+                entering, DEH_String("WIENTER"));
 
     // draw level
     y += (5*SHORT(lnames[wbs->next]->height))/4;
 
+    // [JN] Construct proper patch name for possible error handling:
+    if (gamemode == commercial)
+    {
+        sprintf(lvlname, "CWILV%2.2d", wbs->next);
+    }
+    else
+    {
+        sprintf(lvlname, "WILV%d%d", wbs->epsd, wbs->next);
+    }
+
     V_DrawShadowedPatch((SCREENWIDTH - SHORT(lnames[wbs->next]->width))/2,
 		y, 
-                lnames[wbs->next]);
+                lnames[wbs->next], lvlname);
 
 }
 
@@ -508,14 +530,16 @@ WI_drawOnLnode
 
     if (fits && i<2)
     {
+	// [JN] Note: no bad patch error happening here in fact.
+	// If splat is drawing offscreen, "else" condition will be invoked.
 	V_DrawShadowedPatch(lnodes[wbs->epsd][n].x,
                     lnodes[wbs->epsd][n].y,
-		    c[i]);
+		    c[i], DEH_String("WISPLAT"));
     }
     else
     {
 	// DEBUG
-	printf("Could not place patch on level %d", n+1); 
+	printf("Could not place patch on level %d\n", n+1); 
     }
 }
 
@@ -640,6 +664,7 @@ WI_drawNum
     int		fontwidth = SHORT(num[0]->width);
     int		neg;
     int		temp;
+    char	name[9];
 
     if (digits < 0)
     {
@@ -674,13 +699,15 @@ WI_drawNum
     while (digits--)
     {
 	x -= fontwidth;
-	V_DrawShadowedPatch(x, y, num[ n % 10 ]);
+	// [JN] Construct proper patch name for possible error handling:
+	sprintf(name, "WINUM%d", n);
+	V_DrawShadowedPatch(x, y, num[ n % 10 ], name);
 	n /= 10;
     }
 
     // draw a minus sign if necessary
     if (neg)
-	V_DrawShadowedPatch(x-=8, y, wiminus);
+	V_DrawShadowedPatch(x-=8, y, wiminus, DEH_String("WIMINUS"));
 
     return x;
 
@@ -695,7 +722,7 @@ WI_drawPercent
     if (p < 0)
 	return;
 
-    V_DrawShadowedPatch(x, y, percent);
+    V_DrawShadowedPatch(x, y, percent, DEH_String("WIPCNT"));
     WI_drawNum(x, y, p, -1);
 }
 
@@ -731,14 +758,14 @@ WI_drawTime
 
 	    // draw
 	    if (div==60 || t / div)
-		V_DrawShadowedPatch(x, y, colon);
+		V_DrawShadowedPatch(x, y, colon, DEH_String("WICOLON"));
 	    
 	} while (t / div);
     }
     else
     {
 	// "sucks"
-	V_DrawShadowedPatch(x - SHORT(sucks->width), y, sucks); 
+	V_DrawShadowedPatch(x - SHORT(sucks->width), y, sucks, DEH_String("WISUCKS")); 
     }
 }
 
@@ -1019,6 +1046,7 @@ void WI_drawDeathmatchStats(void)
     int		x;
     int		y;
     int		w;
+    char	name[9];
 
     WI_slamBackground();
     
@@ -1029,10 +1057,10 @@ void WI_drawDeathmatchStats(void)
     // draw stat titles (top line)
     V_DrawShadowedPatch(DM_TOTALSX-SHORT(total->width)/2,
 		DM_MATRIXY-WI_SPACINGY+10,
-		total);
+		total, DEH_String("WIMSTT"));
     
-    V_DrawShadowedPatch(DM_KILLERSX, DM_KILLERSY, killers);
-    V_DrawShadowedPatch(DM_VICTIMSX, DM_VICTIMSY, victims);
+    V_DrawShadowedPatch(DM_KILLERSX, DM_KILLERSY, killers, DEH_String("WIKILRS"));
+    V_DrawShadowedPatch(DM_VICTIMSX, DM_VICTIMSY, victims, DEH_String("WIVCTMS"));
 
     // draw P?
     x = DM_MATRIXX + DM_SPACINGX;
@@ -1042,23 +1070,26 @@ void WI_drawDeathmatchStats(void)
     {
 	if (playeringame[i])
 	{
+	    // [JN] Construct proper patch name for possible error handling:
+	    sprintf(name, "STPB%d", i);
+
 	    V_DrawShadowedPatch(x-SHORT(p[i]->width)/2,
 			DM_MATRIXY - WI_SPACINGY,
-			p[i]);
+			p[i], name);
 	    
 	    V_DrawShadowedPatch(DM_MATRIXX-SHORT(p[i]->width)/2,
 			y,
-			p[i]);
+			p[i], name);
 
 	    if (i == me)
 	    {
 		V_DrawShadowedPatch(x-SHORT(p[i]->width)/2,
 			    DM_MATRIXY - WI_SPACINGY,
-			    bstar);
+			    bstar, DEH_String("STFDEAD0"));
 
 		V_DrawShadowedPatch(DM_MATRIXX-SHORT(p[i]->width)/2,
 			    y,
-			    star);
+			    star, DEH_String("STFST01"));
 	    }
 	}
 	else
@@ -1298,17 +1329,18 @@ void WI_drawNetgameStats(void)
 
     // draw stat titles (top line)
     V_DrawShadowedPatch(NG_STATSX+NG_SPACINGX-SHORT(kills->width),
-		NG_STATSY, kills);
+		NG_STATSY, kills, DEH_String("WIOSTK"));
 
+    // [JN] TODO - add support for French version ("WIOBJ").
     V_DrawShadowedPatch(NG_STATSX+2*NG_SPACINGX-SHORT(items->width),
-		NG_STATSY, items);
+		NG_STATSY, items, DEH_String("WIOSTI"));
 
     V_DrawShadowedPatch(NG_STATSX+3*NG_SPACINGX-SHORT(secret->width),
-		NG_STATSY, secret);
+		NG_STATSY, secret, DEH_String("WIOSTS"));
     
     if (dofrags)
 	V_DrawShadowedPatch(NG_STATSX+4*NG_SPACINGX-SHORT(frags->width),
-		    NG_STATSY, frags);
+		    NG_STATSY, frags, DEH_String("WIFRGS"));
 
     // draw stats
     y = NG_STATSY + SHORT(kills->height);
@@ -1319,10 +1351,13 @@ void WI_drawNetgameStats(void)
 	    continue;
 
 	x = NG_STATSX;
-	V_DrawShadowedPatch(x-SHORT(p[i]->width), y, p[i]);
+
+	// [JN] Construct proper patch name for possible error handling:
+	sprintf(name, "STPB%d", i);
+	V_DrawShadowedPatch(x-SHORT(p[i]->width), y, p[i], name);
 
 	if (i == me)
-	    V_DrawShadowedPatch(x-SHORT(p[i]->width), y, star);
+	    V_DrawShadowedPatch(x-SHORT(p[i]->width), y, star, DEH_String("STFST01"));
 
 	x += NG_SPACINGX;
 	WI_drawPercent(x-pwidth, y+10, cnt_kills[i]);	x += NG_SPACINGX;
@@ -1471,21 +1506,22 @@ void WI_drawStats(void)
     
     WI_drawLF();
 
-    V_DrawShadowedPatch(SP_STATSX, SP_STATSY, kills);
+    V_DrawShadowedPatch(SP_STATSX, SP_STATSY, kills, DEH_String("WIOSTK"));
     WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY, cnt_kills[0]);
 
-    V_DrawShadowedPatch(SP_STATSX, SP_STATSY+lh, items);
+    // [JN] TODO - add support for French version ("WIOBJ").
+    V_DrawShadowedPatch(SP_STATSX, SP_STATSY+lh, items, DEH_String("WIOSTI"));
     WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY+lh, cnt_items[0]);
 
-    V_DrawShadowedPatch(SP_STATSX, SP_STATSY+2*lh, sp_secret);
+    V_DrawShadowedPatch(SP_STATSX, SP_STATSY+2*lh, sp_secret, DEH_String("WISCRT2"));
     WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY+2*lh, cnt_secret[0]);
 
-    V_DrawShadowedPatch(SP_TIMEX, SP_TIMEY, timepatch);
+    V_DrawShadowedPatch(SP_TIMEX, SP_TIMEY, timepatch, DEH_String("WITIME"));
     WI_drawTime(SCREENWIDTH/2 - SP_TIMEX, SP_TIMEY, cnt_time, true);
 
     if (wbs->epsd < 3)
     {
-	V_DrawShadowedPatch(SCREENWIDTH/2 + SP_TIMEX, SP_TIMEY, par);
+	V_DrawShadowedPatch(SCREENWIDTH/2 + SP_TIMEX, SP_TIMEY, par, DEH_String("WIPAR"));
 	WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par, true);
     }
 
@@ -1495,7 +1531,7 @@ void WI_drawStats(void)
         const int ttime = wbs->totaltimes / TICRATE;
         const boolean wide = (ttime > 61*59) || (SP_TIMEX + SHORT(total->width) >= SCREENWIDTH/4);
 
-        V_DrawShadowedPatch((SP_TIMEX), SP_TIMEY + 16, total);
+        V_DrawShadowedPatch((SP_TIMEX), SP_TIMEY + 16, total, DEH_String("WIMSTT"));
         // [crispy] choose x-position depending on width of time string
         WI_drawTime((wide ? SCREENWIDTH : SCREENWIDTH/2) - SP_TIMEX, SP_TIMEY + 16, ttime, false);
     }

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -406,7 +406,23 @@ static patch_t *background;
 // slam background
 void WI_slamBackground(void)
 {
-    V_DrawPatch(0, 0, background);
+    char *name1 = DEH_String("INTERPIC");
+    char  name2[9];
+
+    // [JN] Construct proper patch name for possible error handling:
+    if (gamemode == commercial)
+    {
+        V_DrawPatch(0, 0, background, name1);
+    }
+    else if (gameversion >= exe_ultimate && wbs->epsd == 3)
+    {
+        V_DrawPatch(0, 0, background, name1);
+    }
+    else
+    {
+        sprintf(name2, "WIMAP%d", wbs->epsd);
+        V_DrawPatch(0, 0, background, name2);
+    }
 }
 
 // The ticker is used to detect keys
@@ -458,7 +474,7 @@ void WI_drawLF(void)
         patch_t tmp = { SCREENWIDTH, SCREENHEIGHT, 1, 1, 
                         { 0, 0, 0, 0, 0, 0, 0, 0 } };
 
-        V_DrawPatch(0, y, &tmp);
+        V_DrawPatch(0, y, &tmp, "NULL");
     }
 }
 
@@ -629,6 +645,7 @@ void WI_drawAnimatedBack(void)
 {
     int			i;
     anim_t*		a;
+    char		name[9];
 
     if (gamemode == commercial)
 	return;
@@ -640,8 +657,10 @@ void WI_drawAnimatedBack(void)
     {
 	a = &anims[wbs->epsd][i];
 
+	// [JN] Construct proper patch name for possible error handling:
+	sprintf(name, "WIA%d%.2d%.2d", wbs->epsd, i, a->ctr);
 	if (a->ctr >= 0)
-	    V_DrawPatch(a->loc.x, a->loc.y, a->p[a->ctr]);
+	    V_DrawPatch(a->loc.x, a->loc.y, a->p[a->ctr], name);
     }
 
 }

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -80,7 +80,7 @@ static void SaveDiskData(char *disk_lump, int xoffs, int yoffs)
 
     // Draw the patch and save the result to disk_data.
     disk = W_CacheLumpName(disk_lump, PU_STATIC);
-    V_DrawPatch(loading_disk_xoffs, loading_disk_yoffs, disk);
+    V_DrawPatch(loading_disk_xoffs, loading_disk_yoffs, disk, disk_lump);
     CopyRegion(disk_data, LOADING_DISK_W,
                tmpscreen + yoffs * SCREENWIDTH + xoffs, SCREENWIDTH,
                LOADING_DISK_W, LOADING_DISK_H);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -122,7 +122,7 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source,
 // Masks a column based masked pic to the screen. 
 //
 
-void V_DrawPatch(int x, int y, patch_t *patch)
+void V_DrawPatch(int x, int y, patch_t *patch, char *name)
 { 
     int count;
     int col;
@@ -143,8 +143,8 @@ void V_DrawPatch(int x, int y, patch_t *patch)
     {
 		// RestlessRodent -- Do not die
 		// [JN] ... print a critical message instead.
-		CRL_SetCriticalMessage("V_DrawPatch:"
-        "\rBad V_DrawPatch (vanilla crashes here)", 2);
+        CRL_SetCriticalMessage(M_StringJoin("V_DrawPatch error:",
+        "\rBad V_DrawPatch \"", name, "\"", NULL), 2);
 		return;
     }
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -244,7 +244,7 @@ void V_DrawPatchFlipped(int x, int y, patch_t *patch)
 // Masks a column based masked pic to the screen, with casted shadow
 // -----------------------------------------------------------------------------
 
-void V_DrawShadowedPatch (int x, int y, const patch_t *patch)
+void V_DrawShadowedPatch (int x, int y, const patch_t *patch, char *name)
 {
     int       count, col, w;
     byte     *source, *sourcetrans;
@@ -261,8 +261,8 @@ void V_DrawShadowedPatch (int x, int y, const patch_t *patch)
     ||  y + SHORT(patch->height) > SCREENHEIGHT)
     {
         // [JN] Do not crash, print a critical message instead.
-        CRL_SetCriticalMessage("V_DrawShadowedPatch:"
-        "\rBad V_DrawShadowedPatch (vanilla crashes here)", 2);
+        CRL_SetCriticalMessage(M_StringJoin("V_DrawPatch error:",
+        "\rBad V_DrawPatch \"", name, "\"", NULL), 2);
         return;
     }
 #endif

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -48,7 +48,7 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source,
                 int width, int height,
                 int destx, int desty);
 
-void V_DrawPatch(int x, int y, patch_t *patch);
+void V_DrawPatch(int x, int y, patch_t *patch, char *name);
 void V_DrawPatchFlipped(int x, int y, patch_t *patch);
 void V_DrawShadowedPatch(int x, int y, const patch_t *patch, char *name);
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -50,7 +50,7 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source,
 
 void V_DrawPatch(int x, int y, patch_t *patch);
 void V_DrawPatchFlipped(int x, int y, patch_t *patch);
-void V_DrawShadowedPatch(int x, int y, const patch_t *patch);
+void V_DrawShadowedPatch(int x, int y, const patch_t *patch, char *name);
 
 // Draw a linear block of pixels into the view buffer.
 


### PR DESCRIPTION
Could be slightly optimized by predifining all necessary patch names at startup, instead of continious hitting `DEH_String`, but barely it will give any single penny of benefits.

