### PR TITLE
Optimize palette handling

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -278,7 +278,7 @@ static void D_Display (void)
     // clean up border stuff
     if (gamestate != oldgamestate && gamestate != GS_LEVEL)
     {
-        I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"), PU_CACHE), 0);
+        CRL_ReloadPalette();
     }
 
     // see if the border needs to be initially drawn

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -278,7 +278,7 @@ static void D_Display (void)
     // clean up border stuff
     if (gamestate != oldgamestate && gamestate != GS_LEVEL)
     {
-        I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"), PU_CACHE));
+        I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"), PU_CACHE), 0);
     }
 
     // see if the border needs to be initially drawn

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1268,6 +1268,7 @@ void G_PlayerFinishLevel (int player)
     p->fixedcolormap = 0;		// cancel ir gogles 
     p->damagecount = 0;			// no palette changes 
     p->bonuscount = 0; 
+    st_palette = 0;
 } 
  
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -851,7 +851,7 @@ static void M_DrawCRL_Video (void)
                  crl_fpslimit ? "%d" : "NONE", crl_fpslimit);
     M_WriteText (CRL_MENU_RIGHTOFFSET - M_StringWidth(str), 45, str, 
                  !crl_uncapped_fps ? cr[CR_DARKRED] :
-                 crl_fpslimit ? cr[CR_GREEN] : cr[CR_DARKRED]);
+                 crl_fpslimit ? cr[CR_GREEN] : cr[CR_DARKGREEN]);
 
     // Enable vsync
     sprintf(str, crl_vsync ? "ON" : "OFF");
@@ -986,7 +986,7 @@ static void M_CRL_Gamma (int choice)
             break;
     }
 
-    I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
+    I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE), crl_colorblind);
 }
 
 static void M_CRL_ScreenWipe (int choice)
@@ -1007,7 +1007,8 @@ static void M_CRL_ShowENDOOM (int choice)
 static void M_CRL_Colorblind (int choice)
 {
     crl_colorblind = M_INT_Slider(crl_colorblind, 0, 3, choice);
-    CRL_ReloadPalette();
+
+    I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"), PU_CACHE), 1);
 }
 
 // -----------------------------------------------------------------------------
@@ -2982,7 +2983,7 @@ boolean M_Responder (event_t* ev)
 	    if (crl_gamma > 14)
 		crl_gamma = 0;
 	    CRL_SetMessage(&players[consoleplayer], DEH_String(gammamsg[crl_gamma]), false, NULL);
-            I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
+            I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE), crl_colorblind);
 	    return true;
         }
         // [crispy] those two can be considered as shortcuts for the IDCLEV cheat

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1010,7 +1010,7 @@ static void M_CRL_Colorblind (int choice)
     crl_colorblind = M_INT_Slider(crl_colorblind, 0, 3, choice);
 
     // [JN] 1 - always do a full palette reset when colorblind is changed.
-    I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"), PU_CACHE), 1);
+    I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + st_palette * 768, 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -49,6 +49,7 @@
 #include "p_local.h"
 #include "ct_chat.h"
 #include "v_trans.h"
+#include "st_bar.h"
 
 #include "crlcore.h"
 #include "crlvars.h"
@@ -986,7 +987,7 @@ static void M_CRL_Gamma (int choice)
             break;
     }
 
-    I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE), crl_colorblind);
+    CRL_ReloadPalette();
 }
 
 static void M_CRL_ScreenWipe (int choice)
@@ -1008,6 +1009,7 @@ static void M_CRL_Colorblind (int choice)
 {
     crl_colorblind = M_INT_Slider(crl_colorblind, 0, 3, choice);
 
+    // [JN] 1 - always do a full palette reset when colorblind is changed.
     I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"), PU_CACHE), 1);
 }
 
@@ -2045,6 +2047,7 @@ static void M_EndGameResponse(int key)
     players[consoleplayer].criticalmessageTics = 1;
     players[consoleplayer].message = NULL;
     players[consoleplayer].criticalmessage = NULL;
+    st_palette = 0;
     D_StartTitle ();
 }
 
@@ -2983,7 +2986,7 @@ boolean M_Responder (event_t* ev)
 	    if (crl_gamma > 14)
 		crl_gamma = 0;
 	    CRL_SetMessage(&players[consoleplayer], DEH_String(gammamsg[crl_gamma]), false, NULL);
-            I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE), crl_colorblind);
+	    CRL_ReloadPalette();
 	    return true;
         }
         // [crispy] those two can be considered as shortcuts for the IDCLEV cheat

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -751,7 +751,7 @@ static void ST_updateFaceWidget (void)
 void CRL_ReloadPalette (void)
 {
     byte *pal = (byte *) W_CacheLumpNum (lu_palette, PU_CACHE)+st_palette*768;
-    I_SetPalette (pal);
+    I_SetPalette (pal, crl_colorblind);
 }
 
 // -----------------------------------------------------------------------------
@@ -1392,7 +1392,7 @@ void ST_unloadData(void)
 
 void ST_Start (void)
 {
-    I_SetPalette (W_CacheLumpNum (lu_palette, PU_CACHE));
+    I_SetPalette (W_CacheLumpNum (lu_palette, PU_CACHE), 0);
 
     plyr = &players[displayplayer];
     faceindex = 1; // [crispy] fix status bar face hysteresis across level changes

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -89,7 +89,7 @@ static player_t *plyr;
 
 // lump number for PLAYPAL
 static int lu_palette;
-static int st_palette = 0;
+int st_palette = 0;
 
 // used for evil grin
 static boolean	oldweaponsowned[NUMWEAPONS]; 
@@ -751,6 +751,7 @@ static void ST_updateFaceWidget (void)
 void CRL_ReloadPalette (void)
 {
     byte *pal = (byte *) W_CacheLumpNum (lu_palette, PU_CACHE)+st_palette*768;
+    // [JN] crl_colorblind - do full palette reset if colorblind is enabled.
     I_SetPalette (pal, crl_colorblind);
 }
 
@@ -1392,7 +1393,7 @@ void ST_unloadData(void)
 
 void ST_Start (void)
 {
-    I_SetPalette (W_CacheLumpNum (lu_palette, PU_CACHE), 0);
+    CRL_ReloadPalette();
 
     plyr = &players[displayplayer];
     faceindex = 1; // [crispy] fix status bar face hysteresis across level changes

--- a/src/doom/st_bar.h
+++ b/src/doom/st_bar.h
@@ -65,5 +65,6 @@ extern cheatseq_t cheat_choppers;
 extern cheatseq_t cheat_clev;
 extern cheatseq_t cheat_mypos;
 
+extern int st_palette;
 
 #endif

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -936,7 +936,6 @@ void I_SetPalette (byte *doompalette, int full_reset)
         memmove(palcopy, doompalette, sizeof(palcopy));
         usepal = palcopy;
         CRL_SetColors(palcopy, doompalette);
-        printf("\n !! done full reset !!");
     }
     else
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -921,7 +921,7 @@ void I_ReadScreen (pixel_t* scr)
 //
 // I_SetPalette
 //
-void I_SetPalette (byte *doompalette)
+void I_SetPalette (byte *doompalette, int full_reset)
 {
     int i;
     byte palcopy[768];
@@ -929,9 +929,19 @@ void I_SetPalette (byte *doompalette)
     
     // RestlessRodent -- Make a copy since it the lump is cached,
     // which in this case the colorblindness needs to be set
-    memmove(palcopy, doompalette, sizeof(palcopy));
-    usepal = palcopy;
-    CRL_SetColors(palcopy, doompalette);
+    // [JN] Invoking CRL_SetColors is a bit expensive and 
+    // not really needed if not using colorblind mode.
+    if (full_reset)
+    {
+        memmove(palcopy, doompalette, sizeof(palcopy));
+        usepal = palcopy;
+        CRL_SetColors(palcopy, doompalette);
+        printf("\n !! done full reset !!");
+    }
+    else
+    {
+        usepal = doompalette;
+    }
 
     for (i = 0 ; i < 256 ; ++i)
     {
@@ -1496,8 +1506,9 @@ void I_InitGraphics(void)
 
     // Set the palette
 
+    // [JN] 1 - always generate HOM colors at startup.
     doompal = W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE);
-    I_SetPalette(doompal);
+    I_SetPalette(doompal, 1);
     SDL_SetPaletteColors(screenbuffer->format->palette, palette, 0, 256);
 
     // SDL2-TODO UpdateFocus();

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -48,7 +48,7 @@ void I_ShutdownGraphics(void);
 void I_RenderReadPixels (byte **data, int *w, int *h);
 
 // Takes full 8 bit values.
-void I_SetPalette (byte* palette);
+void I_SetPalette (byte* palette, int full_reset);
 int I_GetPaletteIndex(int r, int g, int b);
 
 void I_FinishUpdate (void);


### PR DESCRIPTION
This fixes small fps dropoffs while running fully uncapped mode in low end PC. In theory, colorblind code can be optimized even more by using some pregenerated values, but maybe later.

TODOs:
* Add some comments/explanations about `0/1/crl_colorblind`.
* Double-check if everything is correct.