### PR TITLE
Windows: use modern icons and system dialog box

### DIFF
--- a/src/i_system.c
+++ b/src/i_system.c
@@ -259,6 +259,10 @@ static boolean already_quitting = false;
 void I_Error (char *error, ...)
 {
     char msgbuf[512];
+#ifdef _WIN32
+    wchar_t win_error_message[1024];  // [JN] UTF-8 retranslation of error message
+    wchar_t win_error_title[128];     // [JN] UTF-8 retranslation of window title
+#endif
     va_list argptr;
     atexit_listentry_t *entry;
     boolean exit_gui_popup;
@@ -308,8 +312,15 @@ void I_Error (char *error, ...)
     // therefore be unable to otherwise see the message).
     if (exit_gui_popup && !I_ConsoleStdout())
     {
+#ifdef _WIN32
+        // [JN] On Windows OS use system, nicer diaalog box.
+        MultiByteToWideChar(CP_UTF8, 0, msgbuf, -1, win_error_message, 1024);
+        MultiByteToWideChar(CP_UTF8, 0, PACKAGE_STRING, -1, win_error_title, 128);
+        MessageBoxW(NULL, win_error_message, win_error_title, MB_ICONSTOP);
+#else
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
                                  PACKAGE_STRING, msgbuf, NULL);
+#endif
     }
 
     // abort();

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -259,10 +259,6 @@ static boolean already_quitting = false;
 void I_Error (char *error, ...)
 {
     char msgbuf[512];
-#ifdef _WIN32
-    wchar_t win_error_message[1024];  // [JN] UTF-8 retranslation of error message
-    wchar_t win_error_title[128];     // [JN] UTF-8 retranslation of window title
-#endif
     va_list argptr;
     atexit_listentry_t *entry;
     boolean exit_gui_popup;
@@ -313,7 +309,11 @@ void I_Error (char *error, ...)
     if (exit_gui_popup && !I_ConsoleStdout())
     {
 #ifdef _WIN32
-        // [JN] On Windows OS use system, nicer diaalog box.
+        // [JN] UTF-8 retranslations of error message and window title.
+        wchar_t win_error_message[1024];
+        wchar_t win_error_title[128];
+
+        // [JN] On Windows OS use system, nicer dialog box.
         MultiByteToWideChar(CP_UTF8, 0, msgbuf, -1, win_error_message, 1024);
         MultiByteToWideChar(CP_UTF8, 0, PACKAGE_STRING, -1, win_error_title, 128);
         MessageBoxW(NULL, win_error_message, win_error_title, MB_ICONSTOP);

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -8,5 +8,17 @@
       <dpiAware>true</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
+  <dependency>
+      <dependentAssembly>
+          <assemblyIdentity
+              type="win32"
+              name="Microsoft.Windows.Common-Controls"
+              version="6.0.0.0"
+              processorArchitecture="*"
+              publicKeyToken="6595b64144ccf1df"
+              language="*"
+          />
+      </dependentAssembly>
+  </dependency>
 </assembly>
 

--- a/src/setup/setup-manifest.xml.in
+++ b/src/setup/setup-manifest.xml.in
@@ -36,6 +36,19 @@
     </application>
   </compatibility>
 
+  <dependency>
+      <dependentAssembly>
+          <assemblyIdentity
+              type="win32"
+              name="Microsoft.Windows.Common-Controls"
+              version="6.0.0.0"
+              processorArchitecture="*"
+              publicKeyToken="6595b64144ccf1df"
+              language="*"
+          />
+      </dependentAssembly>
+  </dependency>
+
   <!-- Declare app as DPI aware, so that Windows Vista and later will not
        apply DPI virtualization. -->
 


### PR DESCRIPTION
@fabiangreffrath, @rfomin, @mikeday0, just FYI, this is small change for small thing, but I'm too addicted to eye-candies. I've been thinking, if program is using flat icon, then why it can't it use flat icon for `I_Error` message as well? Interesting article to read:
https://blog.yuo.be/2018/03/22/the-mystery-of-the-windows-10-message-box-icons/

What we have now:
![image](https://user-images.githubusercontent.com/21193394/229800039-d0ccdc55-1790-4dc9-806a-20b295500a1f.png)
What will happen after changing manifest only. Not really nice, TBH.
![image](https://user-images.githubusercontent.com/21193394/229800090-e5937dfb-0a1e-4f76-8c28-257129c7b866.png)
After changing manifest and switching to use Windows-style dialog box.
![image](https://user-images.githubusercontent.com/21193394/229800139-7aff75d5-aa27-4fd7-b738-660334f67395.png)

I will be able to check these changes XP / 7 / 11 only in the evening.