### PR TITLE
Simplify VSync toggling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ option(ENABLE_SDL2_NET "Enable SDL2_net" On)
 option(ENABLE_SDL2_MIXER "Enable SDL2_mixer" On)
 Option(CMAKE_FIND_PACKAGE_PREFER_CONFIG "Prefer dependency search in config mode over find module mode" OFF)
 
-find_package(SDL2 2.0.7)
+find_package(SDL2 2.0.18)
 if(ENABLE_SDL2_MIXER)
     find_package(SDL2_mixer 2.0.2)
 else()

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -967,7 +967,7 @@ static void M_CRL_VSync (int choice)
 {
     crl_vsync ^= 1;
 
-    I_ReInitGraphics(REINIT_RENDERER | REINIT_TEXTURES | REINIT_ASPECTRATIO);
+    I_ToggleVsync();
 }
 
 static void M_CRL_VisplanesDraw (int choice)

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -108,15 +108,7 @@ void I_GetWindowPosition(int *x, int *y, int w, int h);
 // Joystic/gamepad hysteresis
 extern unsigned int joywait;
 
-enum
-{
-	REINIT_FRAMEBUFFERS = 1,
-	REINIT_RENDERER = 2,
-	REINIT_TEXTURES = 4,
-	REINIT_ASPECTRATIO = 8,
-};
-
-extern void I_ReInitGraphics (int reinit);
+extern void I_ToggleVsync (void);
 
 extern boolean endoom_screen_active;
 


### PR DESCRIPTION
Absolutely same to https://github.com/fabiangreffrath/woof/pull/977. `I_ReInitGraphics` no longer needed as it was used for toggling VSync only.