### PR TITLE
Check if MIDI file have format 0

### DIFF
--- a/src/crlcore.c
+++ b/src/crlcore.c
@@ -1029,9 +1029,29 @@ void CRL_SetColors (uint8_t* colors, void* ref)
 
 // =============================================================================
 //
-//                            Console output coloring
+//                  Critical message, console output coloring
 //
 // =============================================================================
+
+// -----------------------------------------------------------------------------
+// CRL_SetCriticalMessage
+// [JN] Sets critical message parameters.
+//
+// CRL's critical message is always taking second and third HUD line.
+// Unlike common messages, these ones are not binded to player_t structure
+// and may appear independently from any game states and conditions.
+// -----------------------------------------------------------------------------
+
+const char *criticalmessage1;
+const char *criticalmessage2;
+int         criticalmessageTics;
+
+void CRL_SetCriticalMessage (char *message1, char *message2, const int tics)
+{
+    criticalmessage1 = message1;
+    criticalmessage2 = message2;
+    criticalmessageTics = tics;
+}
 
 // -----------------------------------------------------------------------------
 // CRL_printf

--- a/src/crlcore.h
+++ b/src/crlcore.h
@@ -188,16 +188,19 @@ extern void CRL_StatDrawer (void);
 extern void CRL_SetColors (uint8_t* colors, void* ref);
 
 //
-// Console output coloring
+// Critical message, console output coloring
 //
+
+extern const char *criticalmessage1;
+extern const char *criticalmessage2;
+extern int         criticalmessageTics;
+extern void CRL_SetCriticalMessage (char *message1, char *message2, const int tics);
 
 extern void CRL_printf (const char *message, const boolean critical);
 
 //
 // The rest of externals
 //
-
-extern void CRL_SetCriticalMessage (char *message1, char *message2, const int tics);
 
 extern void CRL_WidgetsDrawer (void);
 extern void CRL_ReloadPalette (void);

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -93,10 +93,7 @@ void CRL_DrawMessage (void)
 
 void CRL_DrawCriticalMessage (void)
 {
-    player_t *player = &players[displayplayer];
-
-    if (player->criticalmessageTics <= 0
-    || !player->criticalmessage1 || !player->criticalmessage2)
+    if (criticalmessageTics <= 0 || !criticalmessage1 || !criticalmessage2)
     {
         return;  // No message
     }
@@ -104,13 +101,12 @@ void CRL_DrawCriticalMessage (void)
     if (crl_msg_critical == 0)
     {
         // Static
-        M_WriteTextCritical(9, player->criticalmessage1, player->criticalmessage2,
-                            cr[CR_RED]);
+        M_WriteTextCritical(9, criticalmessage1, criticalmessage2, cr[CR_RED]);
     }
     else
     {
         // Blinking
-        M_WriteTextCritical(9, player->criticalmessage1, player->criticalmessage2,
+        M_WriteTextCritical(9, criticalmessage1, criticalmessage2,
                             gametic & 8 ? cr[CR_DARKRED] : cr[CR_RED]);
     }
 

--- a/src/doom/ct_chat.c
+++ b/src/doom/ct_chat.c
@@ -485,8 +485,8 @@ void MSG_Ticker (void)
     {                           // Refresh the screen when a message goes away
         ultimatemsg = false;    // clear out any chat messages.
     }
-    if (players[displayplayer].criticalmessageTics > 0)
+    if (criticalmessageTics > 0)
     {
-        players[displayplayer].criticalmessageTics--;
+        criticalmessageTics--;
     }
 }

--- a/src/doom/d_player.h
+++ b/src/doom/d_player.h
@@ -144,11 +144,6 @@ typedef struct player_s
     // [JN] CRL - prevent other than typing actions in G_Responder
     // while cheat tics are ticking.
     int			cheatTics;
-
-    // [JN] CRL - hint critical messages.
-    const char*	criticalmessage1;
-    const char*	criticalmessage2;
-    int			criticalmessageTics;
     
     // [JN] CRL - target's health.
     const char*	targetsname;

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -126,10 +126,11 @@ void F_StartFinale (void)
     finale_wipe_done = false;
     players[consoleplayer].cheatTics = 1;
     players[consoleplayer].messageTics = 1;
-    players[consoleplayer].criticalmessageTics = 1;
     players[consoleplayer].message = NULL;
-    players[consoleplayer].criticalmessage1 = NULL;
-    players[consoleplayer].criticalmessage2 = NULL;
+    // [JN] Keep critical message visible.
+    // criticalmessageTics = 1;
+    // criticalmessage1 = NULL;
+    // criticalmessage2 = NULL;
 
     if (logical_gamemission == doom)
     {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1517,7 +1517,8 @@ void G_PlayerFinishLevel (int player)
     memset (p->cards, 0, sizeof (p->cards)); 
     p->cheatTics = 0;
     p->messageTics = 0;
-    p->criticalmessageTics = 0;
+    // [JN] Keep critical message visible.
+    // criticalmessageTics = 0;
     p->targetsheathTics = 0;
     p->mo->flags &= ~MF_SHADOW;		// cancel invisibility 
     p->extralight = 0;			// cancel gun flashes 
@@ -1572,7 +1573,8 @@ void G_PlayerReborn (int player)
     p->weaponowned[wp_pistol] = true; 
     p->ammo[am_clip] = deh_initial_bullets; 
     p->messageTics = 0;
-    p->criticalmessageTics = 0;
+    // [JN] Keep critical message visible.
+    // criticalmessageTics = 0;
     p->targetsheathTics = 0;
 	 
     for (i=0 ; i<NUMAMMO ; i++) 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -3762,10 +3762,10 @@ static void M_EndGameResponse(int key)
     currentMenu->lastOn = itemOn;
     M_ClearMenus ();
     players[consoleplayer].messageTics = 1;
-    players[consoleplayer].criticalmessageTics = 1;
     players[consoleplayer].message = NULL;
-    players[consoleplayer].criticalmessage1 = NULL;
-    players[consoleplayer].criticalmessage2 = NULL;
+    criticalmessageTics = 1;
+    criticalmessage1 = NULL;
+    criticalmessage2 = NULL;
     st_palette = 0;
     D_StartTitle ();
 }

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -69,17 +69,6 @@ void CRL_SetMessage (player_t *player, const char *message, boolean ultmsg, byte
     }
 }
 
-// -----------------------------------------------------------------------------
-// CRL_SetCriticalMessage
-// [JN] Sets critical message parameters.
-// -----------------------------------------------------------------------------
-
-void CRL_SetCriticalMessage (char *message1, char *message2, const int tics)
-{
-    players[consoleplayer].criticalmessage1 = message1;
-    players[consoleplayer].criticalmessage2 = message2;
-    players[consoleplayer].criticalmessageTics = tics;
-}
 
 //
 // GET STUFF

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -40,6 +40,7 @@ typedef fluid_long_long_t fluid_int_t;
 #include "i_sound.h"
 #include "m_misc.h"
 #include "memio.h"
+#include "midifile.h"
 #include "mus2mid.h"
 
 char *fsynth_sf_path = "";
@@ -223,6 +224,7 @@ static void *I_FL_RegisterSong(void *data, int len)
     if (IsMid(data, len))
     {
         result = fluid_player_add_mem(player, data, len);
+        MIDI_CheckFile(data, len);
 
         if (result == FLUID_FAILED)
         {

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -224,6 +224,7 @@ static void *I_FL_RegisterSong(void *data, int len)
     if (IsMid(data, len))
     {
         result = fluid_player_add_mem(player, data, len);
+        // [JN] CRL - Check if MIDI file is valid.
         MIDI_CheckFile(data, len);
 
         if (result == FLUID_FAILED)

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1674,6 +1674,7 @@ static void *I_OPL_RegisterSong(void *data, int len)
     if (IsMid(data, len) && len < MAXMIDLENGTH)
     {
         M_WriteFile(filename, data, len);
+        MIDI_CheckFile(data, len);
     }
     else
     {

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1674,6 +1674,7 @@ static void *I_OPL_RegisterSong(void *data, int len)
     if (IsMid(data, len) && len < MAXMIDLENGTH)
     {
         M_WriteFile(filename, data, len);
+        // [JN] CRL - Check if MIDI file is valid.
         MIDI_CheckFile(data, len);
     }
     else

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -388,6 +388,7 @@ static void *I_SDL_RegisterSong(void *data, int len)
     if (IsMid(data, len) && len < MAXMIDLENGTH)
     {
         M_WriteFile(filename, data, len);
+        // [JN] CRL - Check if MIDI file is valid.
         MIDI_CheckFile(data, len);
     }
     else

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "doomtype.h"
 #include "memio.h"
+#include "midifile.h"
 #include "mus2mid.h"
 
 #include "deh_str.h"
@@ -387,6 +388,7 @@ static void *I_SDL_RegisterSong(void *data, int len)
     if (IsMid(data, len) && len < MAXMIDLENGTH)
     {
         M_WriteFile(filename, data, len);
+        MIDI_CheckFile(data, len);
     }
     else
     {

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1754,6 +1754,7 @@ static void *I_WIN_RegisterSong(void *data, int len)
     if (IsMid(data, len))
     {
         M_WriteFile(filename, data, len);
+        // [JN] CRL - Check if MIDI file is valid.
         MIDI_CheckFile(data, len);
     }
     else

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1754,6 +1754,7 @@ static void *I_WIN_RegisterSong(void *data, int len)
     if (IsMid(data, len))
     {
         M_WriteFile(filename, data, len);
+        MIDI_CheckFile(data, len);
     }
     else
     {

--- a/src/midifile.c
+++ b/src/midifile.c
@@ -569,6 +569,14 @@ static boolean ReadFileHeader(midi_file_t *file, FILE *stream)
 }
 
 // Check if MIDI file is valid.
+//
+// [JN] CRL-specific function for checking if MIDI have 0 format.
+// This is critical for DOS version of Vanilla Doom, see:
+// - source: https://www.doomworld.com/forum/post/2541624
+// - issue: https://github.com/chocolate-doom/chocolate-doom/issues/1645
+// - code: https://github.com/chocolate-doom/chocolate-doom/pull/1647
+// 
+// Many thanks to ceski and Arsinikk for heads up, investigation and fix!
 
 boolean MIDI_CheckFile(void *data, int len)
 {

--- a/src/midifile.c
+++ b/src/midifile.c
@@ -570,8 +570,6 @@ static boolean ReadFileHeader(midi_file_t *file, FILE *stream)
 
 // Check if MIDI file is valid.
 
-boolean MIDI_unsupported_warning;
-
 boolean MIDI_CheckFile(void *data, int len)
 {
     unsigned int format_type = 0;
@@ -642,8 +640,8 @@ boolean MIDI_CheckFile(void *data, int len)
         // Source: https://www.doomworld.com/forum/post/2541624
         if (reported_len + 3 > actual_len)
         {
-            MIDI_unsupported_warning = true;
-            CRL_printf("MIDI_CheckFile: Format 0 MIDI files not supported by vanilla Doom!", true);
+            CRL_printf("MIDI_CheckFile: Format 0 MIDI files not supported by Vanilla Doom!", true);
+            CRL_SetCriticalMessage("MIDI_CheckFile:", "Format 0 MIDI is not supported by Vanilla!", 4 * 35);
         }
     }
 

--- a/src/midifile.c
+++ b/src/midifile.c
@@ -22,11 +22,13 @@
 #include <string.h>
 #include <assert.h>
 
-#include "doomtype.h"
 #include "i_swap.h"
 #include "i_system.h"
 #include "m_misc.h"
+#include "memio.h"
 #include "midifile.h"
+
+#include "crlcore.h"
 
 #define HEADER_CHUNK_ID "MThd"
 #define TRACK_CHUNK_ID  "MTrk"
@@ -563,6 +565,89 @@ static boolean ReadFileHeader(midi_file_t *file, FILE *stream)
         return false;
     }
 
+    return true;
+}
+
+// Check if MIDI file is valid.
+
+boolean MIDI_unsupported_warning;
+
+boolean MIDI_CheckFile(void *data, int len)
+{
+    unsigned int format_type = 0;
+    midi_file_t file;
+    MEMFILE *stream = mem_fopen_read(data, len);
+
+    if (stream == NULL)
+    {
+        return false;
+    }
+
+    // Read header chunk.
+    if (!mem_fread(&file.header, sizeof(midi_header_t), 1, stream))
+    {
+        mem_fclose(stream);
+        return false;
+    }
+
+    // Check header chunk.
+    if (!CheckChunkHeader(&file.header.chunk_header, HEADER_CHUNK_ID) ||
+        SDL_SwapBE32(file.header.chunk_header.chunk_size) != 6)
+    {
+        mem_fclose(stream);
+        return false;
+    }
+
+    // Check file info.
+    format_type = SDL_SwapBE16(file.header.format_type);
+    file.num_tracks = SDL_SwapBE16(file.header.num_tracks);
+    if (format_type > 1 || file.num_tracks < 1)
+    {
+        mem_fclose(stream);
+        return false;
+    }
+
+    // Handle format 0 special case.
+    if (format_type == 0)
+    {
+        chunk_header_t chunk_header;
+        unsigned int reported_len = 0;
+        long actual_len = 0;
+
+        // Read track chunk.
+        if (file.num_tracks != 1 ||
+            !mem_fread(&chunk_header, sizeof(chunk_header_t), 1, stream))
+        {
+            mem_fclose(stream);
+            return false;
+        }
+
+        // Check track chunk.
+        if (!CheckChunkHeader(&chunk_header, TRACK_CHUNK_ID))
+        {
+            mem_fclose(stream);
+            return false;
+        }
+
+        // Reported track data length.
+        reported_len = SDL_SwapBE32(chunk_header.chunk_size);
+
+        // Actual track data length.
+        actual_len = mem_ftell(stream);
+        mem_fseek(stream, 0, MEM_SEEK_END);
+        actual_len = mem_ftell(stream) - actual_len;
+
+        // In Vanilla Doom, loading a format 0 MIDI file causes heap corruption
+        // unless 3 or more dummy bytes are added to the end of the file.
+        // Source: https://www.doomworld.com/forum/post/2541624
+        if (reported_len + 3 > actual_len)
+        {
+            MIDI_unsupported_warning = true;
+            CRL_printf("MIDI_CheckFile: Format 0 MIDI files not supported by vanilla Doom!", true);
+        }
+    }
+
+    mem_fclose(stream);
     return true;
 }
 

--- a/src/midifile.h
+++ b/src/midifile.h
@@ -20,6 +20,8 @@
 #ifndef MIDIFILE_H
 #define MIDIFILE_H
 
+#include "doomtype.h"
+
 typedef struct midi_file_s midi_file_t;
 typedef struct midi_track_iter_s midi_track_iter_t;
 
@@ -185,6 +187,11 @@ typedef struct
         midi_sysex_event_data_t sysex;
     } data;
 } midi_event_t;
+
+// Check if MIDI file is valid.
+
+extern boolean MIDI_unsupported_warning;
+boolean MIDI_CheckFile(void *data, int len);
 
 // Load a MIDI file.
 

--- a/src/midifile.h
+++ b/src/midifile.h
@@ -190,7 +190,6 @@ typedef struct
 
 // Check if MIDI file is valid.
 
-extern boolean MIDI_unsupported_warning;
 boolean MIDI_CheckFile(void *data, int len);
 
 // Load a MIDI file.


### PR DESCRIPTION
This adds "soft" check for MIDI file format 0. If deceted, an in-game and console warnings will be printed, since such format is not suppored by DOS version of Vanilla Doom, see:

- source: https://www.doomworld.com/forum/post/2541624
- issue: https://github.com/chocolate-doom/chocolate-doom/issues/1645
- code: https://github.com/chocolate-doom/chocolate-doom/pull/1647

No error-quit or stop music playing, just a warnings.

Dear @ceski-1, dear @andrikpowell, thank you very much for heads up, investigation and fix! It is absolutely clear why such check can't exist in Chocolate Doom, aside from zillions of WADs, there is console output on Windows there, and such thing as in-game warning is definitely out of scope as completely nonclinical. Here's however, is a perfect place for such check, so no efforts will be lost. 🙂