### PR TITLE
Fast mouse polling for lower lag interpolation

### DIFF
--- a/src/d_event.c
+++ b/src/d_event.c
@@ -26,7 +26,8 @@
 
 #define MAXEVENTS 64
 
-// [crispy]
+// [crispy] For fast polling
+// Written by ceski, Michael Day and Roman Fomin, thanks!
 event_t fastmouse;
 boolean newfastmouse;
 

--- a/src/d_event.c
+++ b/src/d_event.c
@@ -26,6 +26,10 @@
 
 #define MAXEVENTS 64
 
+// [crispy]
+event_t fastmouse;
+boolean newfastmouse;
+
 static event_t events[MAXEVENTS];
 static int eventhead;
 static int eventtail;

--- a/src/d_event.h
+++ b/src/d_event.h
@@ -136,7 +136,10 @@ typedef enum
 } buttoncode2_t;
 
 
+// [crispy] For fast polling
+extern event_t fastmouse;
 
+extern boolean newfastmouse;
 
 // Called by IO functions when input is detected.
 void D_PostEvent (event_t *ev);

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1751,7 +1751,6 @@ static void AM_drawPlayers (void)
         }
         else
         {
-            //smoothangle = R_InterpolateAngle(p->mo->oldangle, p->mo->angle, fractionaltic);
             smoothangle = LerpAngle(p->mo->oldangle, p->mo->angle);
         }
 
@@ -1792,12 +1791,9 @@ static void AM_drawThings (void)
             // [JN] Interpolate things if possible.
             if (crl_uncapped_fps && realleveltime > oldleveltime)
             {
-                // pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-                // pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
                 pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
                 pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
                 actualangle = LerpAngle(t->oldangle, t->angle);
-                //actualangle = R_InterpolateAngle(t->oldangle, t->angle, fractionaltic);
             }
             else
             {
@@ -1874,11 +1870,6 @@ static void AM_drawSpectator (void)
             // [JN] Interpolate things if possible.
             if (crl_uncapped_fps && realleveltime > oldleveltime)
             {
-                /*
-                pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-                pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
-                actualangle = R_InterpolateAngle(t->oldangle, t->angle, fractionaltic);
-                */
                 pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
                 pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
                 actualangle = LerpAngle(t->oldangle, t->angle);

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1728,8 +1728,8 @@ static void AM_drawPlayers (void)
         // [JN] Interpolate other player arrows.
         if (crl_uncapped_fps && realleveltime > oldleveltime)
         {
-            pt.x = (p->mo->oldx + FixedMul(p->mo->x - p->mo->oldx, fractionaltic)) >> FRACTOMAPBITS;
-            pt.y = (p->mo->oldy + FixedMul(p->mo->y - p->mo->oldy, fractionaltic)) >> FRACTOMAPBITS;
+            pt.x = LerpFixed(p->mo->oldx, p->mo->x) >> FRACTOMAPBITS;
+            pt.y = LerpFixed(p->mo->oldy, p->mo->y) >> FRACTOMAPBITS;
         }
         else
         {
@@ -1751,7 +1751,8 @@ static void AM_drawPlayers (void)
         }
         else
         {
-            smoothangle = R_InterpolateAngle(p->mo->oldangle, p->mo->angle, fractionaltic);
+            //smoothangle = R_InterpolateAngle(p->mo->oldangle, p->mo->angle, fractionaltic);
+            smoothangle = LerpAngle(p->mo->oldangle, p->mo->angle);
         }
 
         AM_drawLineCharacter(player_arrow, arrlen(player_arrow), 0,
@@ -1791,9 +1792,12 @@ static void AM_drawThings (void)
             // [JN] Interpolate things if possible.
             if (crl_uncapped_fps && realleveltime > oldleveltime)
             {
-                pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-                pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
-                actualangle = R_InterpolateAngle(t->oldangle, t->angle, fractionaltic);
+                // pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
+                // pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
+                pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
+                pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
+                actualangle = LerpAngle(t->oldangle, t->angle);
+                //actualangle = R_InterpolateAngle(t->oldangle, t->angle, fractionaltic);
             }
             else
             {
@@ -1870,9 +1874,14 @@ static void AM_drawSpectator (void)
             // [JN] Interpolate things if possible.
             if (crl_uncapped_fps && realleveltime > oldleveltime)
             {
+                /*
                 pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
                 pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
                 actualangle = R_InterpolateAngle(t->oldangle, t->angle, fractionaltic);
+                */
+                pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
+                pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
+                actualangle = LerpAngle(t->oldangle, t->angle);
             }
             else
             {

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -133,12 +133,6 @@ void CRL_Get_MAX (void)
     {
         if (crl_uncapped_fps)
         {
-            /*
-            CRL_MAX_x = CRL_camera_oldx + FixedMul(CRL_camera_x - CRL_camera_oldx, fractionaltic);
-            CRL_MAX_y = CRL_camera_oldy + FixedMul(CRL_camera_y - CRL_camera_oldy, fractionaltic);
-            CRL_MAX_z = CRL_camera_oldz + FixedMul(CRL_camera_z - CRL_camera_oldz, fractionaltic) - VIEWHEIGHT;
-            CRL_MAX_ang = R_InterpolateAngle(CRL_camera_oldang, CRL_camera_ang, fractionaltic);
-            */
             CRL_MAX_x = LerpFixed(CRL_camera_oldx, CRL_camera_x);
             CRL_MAX_y = LerpFixed(CRL_camera_oldy, CRL_camera_y);
             CRL_MAX_z = LerpFixed(CRL_camera_oldz, CRL_camera_z) - VIEWHEIGHT;
@@ -156,15 +150,9 @@ void CRL_Get_MAX (void)
     {
         if (crl_uncapped_fps)
         {
-            /*
-            CRL_MAX_x = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-            CRL_MAX_y = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-            CRL_MAX_z = player->mo->oldz + FixedMul(player->mo->z - player->mo->oldz, fractionaltic);
-            CRL_MAX_ang = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic);
-            */
             CRL_MAX_x = LerpFixed(player->mo->oldx, player->mo->x);
-            CRL_MAX_y = LerpFixed(player->mo->oldy, player->mo->oldy);
-            CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->oldz);
+            CRL_MAX_y = LerpFixed(player->mo->oldy, player->mo->y);
+            CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->z);
             CRL_MAX_ang = LerpAngle(player->mo->oldangle, player->mo->angle);
         }
         else

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -127,9 +127,18 @@ void CRL_Clear_MAX (void)
 
 void CRL_Get_MAX (void)
 {
+    player_t *player = &players[displayplayer];
+    
     CRL_MAX_x = viewx;
     CRL_MAX_y = viewy;
-    CRL_MAX_z = viewz - VIEWHEIGHT;
+    if (!crl_spectating)
+    {
+        CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->z);
+    }
+    else
+    {
+        CRL_MAX_z = LerpFixed(CRL_camera_oldz, CRL_camera_z) - VIEWHEIGHT;
+    }
     CRL_MAX_ang = viewangle;
 }
 

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -131,13 +131,13 @@ void CRL_Get_MAX (void)
     
     CRL_MAX_x = viewx;
     CRL_MAX_y = viewy;
-    if (!crl_spectating)
+    if (crl_spectating)
     {
-        CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->z);
+        CRL_MAX_z = LerpFixed(CRL_camera_oldz, CRL_camera_z) - VIEWHEIGHT;
     }
     else
     {
-        CRL_MAX_z = LerpFixed(CRL_camera_oldz, CRL_camera_z) - VIEWHEIGHT;
+        CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->z);
     }
     CRL_MAX_ang = viewangle;
 }

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -128,7 +128,7 @@ void CRL_Clear_MAX (void)
 void CRL_Get_MAX (void)
 {
     player_t *player = &players[displayplayer];
-    
+
     CRL_MAX_x = viewx;
     CRL_MAX_y = viewy;
     if (crl_spectating)

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -133,10 +133,16 @@ void CRL_Get_MAX (void)
     {
         if (crl_uncapped_fps)
         {
+            /*
             CRL_MAX_x = CRL_camera_oldx + FixedMul(CRL_camera_x - CRL_camera_oldx, fractionaltic);
             CRL_MAX_y = CRL_camera_oldy + FixedMul(CRL_camera_y - CRL_camera_oldy, fractionaltic);
             CRL_MAX_z = CRL_camera_oldz + FixedMul(CRL_camera_z - CRL_camera_oldz, fractionaltic) - VIEWHEIGHT;
             CRL_MAX_ang = R_InterpolateAngle(CRL_camera_oldang, CRL_camera_ang, fractionaltic);
+            */
+            CRL_MAX_x = LerpFixed(CRL_camera_oldx, CRL_camera_x);
+            CRL_MAX_y = LerpFixed(CRL_camera_oldy, CRL_camera_y);
+            CRL_MAX_z = LerpFixed(CRL_camera_oldz, CRL_camera_z) - VIEWHEIGHT;
+            CRL_MAX_ang = LerpAngle(CRL_camera_oldang, CRL_camera_ang);
         }
         else
         {
@@ -150,10 +156,16 @@ void CRL_Get_MAX (void)
     {
         if (crl_uncapped_fps)
         {
+            /*
             CRL_MAX_x = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
             CRL_MAX_y = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
             CRL_MAX_z = player->mo->oldz + FixedMul(player->mo->z - player->mo->oldz, fractionaltic);
             CRL_MAX_ang = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic);
+            */
+            CRL_MAX_x = LerpFixed(player->mo->oldx, player->mo->x);
+            CRL_MAX_y = LerpFixed(player->mo->oldy, player->mo->oldy);
+            CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->oldz);
+            CRL_MAX_ang = LerpAngle(player->mo->oldangle, player->mo->angle);
         }
         else
         {

--- a/src/doom/crlfunc.c
+++ b/src/doom/crlfunc.c
@@ -127,42 +127,10 @@ void CRL_Clear_MAX (void)
 
 void CRL_Get_MAX (void)
 {
-    player_t *player = &players[displayplayer];
-
-    if (crl_spectating)
-    {
-        if (crl_uncapped_fps)
-        {
-            CRL_MAX_x = LerpFixed(CRL_camera_oldx, CRL_camera_x);
-            CRL_MAX_y = LerpFixed(CRL_camera_oldy, CRL_camera_y);
-            CRL_MAX_z = LerpFixed(CRL_camera_oldz, CRL_camera_z) - VIEWHEIGHT;
-            CRL_MAX_ang = LerpAngle(CRL_camera_oldang, CRL_camera_ang);
-        }
-        else
-        {
-            CRL_MAX_x = CRL_camera_x;
-            CRL_MAX_y = CRL_camera_y;
-            CRL_MAX_z = CRL_camera_z - VIEWHEIGHT;
-            CRL_MAX_ang = CRL_camera_ang;
-        }
-    }
-    else
-    {
-        if (crl_uncapped_fps)
-        {
-            CRL_MAX_x = LerpFixed(player->mo->oldx, player->mo->x);
-            CRL_MAX_y = LerpFixed(player->mo->oldy, player->mo->y);
-            CRL_MAX_z = LerpFixed(player->mo->oldz, player->mo->z);
-            CRL_MAX_ang = LerpAngle(player->mo->oldangle, player->mo->angle);
-        }
-        else
-        {
-            CRL_MAX_x = player->mo->x;
-            CRL_MAX_y = player->mo->y;
-            CRL_MAX_z = player->mo->z;
-            CRL_MAX_ang = player->mo->angle;
-        }
-    }
+    CRL_MAX_x = viewx;
+    CRL_MAX_y = viewy;
+    CRL_MAX_z = viewz - VIEWHEIGHT;
+    CRL_MAX_ang = viewangle;
 }
 
 void CRL_MoveTo_MAX (void)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -241,6 +241,13 @@ static void D_Display (void)
         return;  // for comparative timing / profiling
     }
 
+    if (crl_uncapped_fps)
+    {
+        I_StartDisplay();
+        G_FastResponder();
+        G_PrepTiccmd();
+    }
+
     // change the view size if needed
     if (setsizeneeded)
     {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -380,21 +380,6 @@ static double CalcMouseAngle(int mousex)
     return (I_AccelerateMouse(mousex) * (mouseSensitivity + 5) * 8 / 10);
 }
 
-static double CalcMouseSide(int mousex)
-{
-    //if (!mouseSensitivity_x2)
-        return 0.0;
-
-    //return (I_AccelerateMouse(mousex) * (mouseSensitivity_x2 + 5) * 2 / 10);
-}
-
-static double CalcMouseVert(int mousey)
-{
-    //if (!mouseSensitivity_y)
-        return 0.0;
-
-    //return (I_AccelerateMouseY(mousey) * (mouseSensitivity_y + 5) / 10);
-}
 
 //
 // G_BuildTiccmd
@@ -802,7 +787,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 
     if (!novert)
     {
-    forward += CarryMouseVert(CalcMouseVert(mousey));
+    forward += CarryMouseVert(mousey);
     }
 
 /*
@@ -814,7 +799,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     else 
     {
         if (!crl_spectating)
-        cmd->angleturn += CarryMouseSide(CalcMouseSide(mousex));
+        cmd->angleturn += CarryMouseSide(mousex);
         else
         {
             if (crl_uncapped_fps)
@@ -1429,15 +1414,6 @@ void G_PrepTiccmd (void)
         localview.angle = (basecmd.angleturn << 16);
         mousex = 0;
     }
-/*
-    if (mousey && crispy->mouselook)
-    {
-        const double vert = CalcMouseVert(mousey);
-        basecmd.lookdir += mouse_y_invert ?
-                            CarryPitch(-vert): CarryPitch(vert);
-        mousey = 0;
-    }
-*/
 }
 
 // [crispy] re-read game parameters from command line

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -198,6 +198,18 @@ static boolean *mousebuttons = &mousearray[1];  // allow [-1]
 int             mousex;
 int             mousey;         
 
+// [crispy] for rounding error
+typedef struct carry_s
+{
+    double angle;
+    double pitch;
+    double side;
+    double vert;
+} carry_t;
+
+static carry_t prevcarry;
+static carry_t carry;
+
 static int      dclicktime;
 static boolean  dclickstate;
 static int      dclicks; 
@@ -216,6 +228,7 @@ char            savename[256]; // [crispy] moved here
 static int      savegameslot; 
 static char     savedescription[32]; 
  
+static ticcmd_t basecmd; // [crispy]
 #define	BODYQUESIZE	32
 
 mobj_t*		bodyque[BODYQUESIZE]; 
@@ -324,6 +337,63 @@ boolean speedkeydown (void)
            (joybspeed < MAX_JOY_BUTTONS && joybuttons[joybspeed]);
 }
 
+// [crispy] for carrying rounding error
+static int CarryError(double value, const double *prevcarry, double *carry)
+{
+    const double desired = value + *prevcarry;
+    const int actual = lround(desired);
+    *carry = desired - actual;
+
+    return actual;
+}
+
+static short CarryAngle(double angle)
+{
+    return CarryError(angle, &prevcarry.angle, &carry.angle);
+}
+
+static short CarryPitch(double pitch)
+{
+    return CarryError(pitch, &prevcarry.pitch, &carry.pitch);
+}
+
+static int CarryMouseVert(double vert)
+{
+    return CarryError(vert, &prevcarry.vert, &carry.vert);
+}
+
+static int CarryMouseSide(double side)
+{
+    const double desired = side + prevcarry.side;
+    const int actual = lround(side * 0.5) * 2; // Even values only.
+    carry.side = desired - actual;
+    return actual;
+}
+
+static double CalcMouseAngle(int mousex)
+{
+    if (!mouseSensitivity)
+        return 0.0;
+
+    return (I_AccelerateMouse(mousex) * (mouseSensitivity + 5) * 8 / 10);
+}
+
+static double CalcMouseSide(int mousex)
+{
+    //if (!mouseSensitivity_x2)
+        return 0.0;
+
+    //return (I_AccelerateMouse(mousex) * (mouseSensitivity_x2 + 5) * 2 / 10);
+}
+
+static double CalcMouseVert(int mousey)
+{
+    //if (!mouseSensitivity_y)
+        return 0.0;
+
+    //return (I_AccelerateMouseY(mousey) * (mouseSensitivity_y + 5) / 10);
+}
+
 //
 // G_BuildTiccmd
 // Builds a ticcmd from all of the available inputs
@@ -337,11 +407,15 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     boolean	bstrafe; 
     int		speed;
     int		tspeed; 
+    int		angle = 0; // [crispy]
     int		forward;
     int		side;
     ticcmd_t spect;
 
-    memset(cmd, 0, sizeof(ticcmd_t));
+    // [crispy] For fast polling.
+    G_PrepTiccmd();
+    memcpy(cmd, &basecmd, sizeof(*cmd));
+    memset(&basecmd, 0, sizeof(ticcmd_t));
 
 	// needed for net games
     cmd->consistancy = consistancy[consoleplayer][maketic%BACKUPTICS]; 
@@ -390,7 +464,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_180turn])
     {
-        cmd->angleturn += ANG180 >> FRACBITS;
+        angle += ANG180 >> FRACBITS;
         gamekeydown[key_180turn] = false;
     }
 
@@ -430,51 +504,54 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     // let movement keys cancel each other out
     if (strafe) 
     { 
-	if (gamekeydown[key_right]) 
-	{
-	    // fprintf(stderr, "strafe right\n");
-	    side += sidemove[speed]; 
-	}
-	if (gamekeydown[key_left]) 
-	{
-	    //	fprintf(stderr, "strafe left\n");
-	    side -= sidemove[speed]; 
-	}
-        if (use_analog && joyxmove)
+        if (!cmd->angleturn)
         {
-            joyxmove = joyxmove * joystick_move_sensitivity / 10;
-            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
-            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
-            side += FixedMul(sidemove[speed], joyxmove);
-        }
-        else if (joystick_move_sensitivity)
-        {
-            if (joyxmove > 0)
+            if (gamekeydown[key_right])
+            {
+                // fprintf(stderr, "strafe right\n");
                 side += sidemove[speed];
-            if (joyxmove < 0)
+            }
+            if (gamekeydown[key_left])
+            {
+                //	fprintf(stderr, "strafe left\n");
                 side -= sidemove[speed];
+            }
+            if (use_analog && joyxmove)
+            {
+                joyxmove = joyxmove * joystick_move_sensitivity / 10;
+                joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+                joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+                side += FixedMul(sidemove[speed], joyxmove);
+            }
+            else if (joystick_move_sensitivity)
+            {
+                if (joyxmove > 0)
+                    side += sidemove[speed];
+                if (joyxmove < 0)
+                    side -= sidemove[speed];
+            }
         }
     } 
     else 
     { 
 	if (gamekeydown[key_right]) 
-	    cmd->angleturn -= angleturn[tspeed]; 
+	    angle -= angleturn[tspeed]; 
 	if (gamekeydown[key_left]) 
-	    cmd->angleturn += angleturn[tspeed]; 
+	    angle += angleturn[tspeed]; 
         if (use_analog && joyxmove)
         {
             // Cubic response curve allows for finer control when stick
             // deflection is small.
             joyxmove = FixedMul(FixedMul(joyxmove, joyxmove), joyxmove);
             joyxmove = joyxmove * joystick_turn_sensitivity / 10;
-            cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
+            angle -= FixedMul(angleturn[1], joyxmove);
         }
         else if (joystick_turn_sensitivity)
         {
             if (joyxmove > 0)
-                cmd->angleturn -= angleturn[tspeed];
+                angle -= angleturn[tspeed];
             if (joyxmove < 0)
-                cmd->angleturn += angleturn[tspeed];
+                angle += angleturn[tspeed];
         }
     } 
  
@@ -712,13 +789,17 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 
     if (!novert)
     {
-    forward += mousey;
+    forward += CarryMouseVert(CalcMouseVert(mousey));
     }
 
+    if (strafe && !cmd->angleturn)
+	side += CarryMouseSide(CalcMouseSide(mousex));
+/*
     if (strafe) 
 	side += mousex*2;
     else 
 	cmd->angleturn -= mousex*0x8; 
+*/
 
     if (mousex == 0)
     {
@@ -727,6 +808,13 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         testcontrols_mousespeed = 0;
     }
     
+    if (angle)
+    {
+        const short old_angleturn = cmd->angleturn;
+        cmd->angleturn = CarryAngle(localview.rawangle + angle);
+        localview.ticangleturn = (cmd->angleturn - old_angleturn);
+    }
+
     mousex = mousey = 0;
 	 
     if (forward > MAXPLMOVE) 
@@ -740,6 +828,11 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
  
     cmd->forwardmove += forward; 
     cmd->sidemove += side;
+
+    // [crispy]
+    localview.angle = 0;
+    localview.rawangle = 0.0;
+    prevcarry = carry;
     
     // special buttons
     if (sendpause) 
@@ -880,6 +973,10 @@ void G_DoLoadLevel (void)
     memset (gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = 0;
     mousex = mousey = 0;
+    memset(&localview, 0, sizeof(localview)); // [crispy]
+    memset(&carry, 0, sizeof(carry)); // [crispy]
+    memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]
+    memset(&basecmd, 0, sizeof(basecmd)); // [crispy]
     sendpause = sendsave = paused = false;
     memset(mousearray, 0, sizeof(mousearray));
     memset(joyarray, 0, sizeof(joyarray));
@@ -1262,8 +1359,8 @@ boolean G_Responder (event_t* ev)
 		 
       case ev_mouse: 
         SetMouseButtons(ev->data1);
-	mousex = ev->data2*(mouseSensitivity+5)/10; 
-	mousey = ev->data3*(mouseSensitivity+5)/10; 
+        mousex += ev->data2;
+        mousey += ev->data3;
 	return true;    // eat events 
  
       case ev_joystick: 
@@ -1280,7 +1377,42 @@ boolean G_Responder (event_t* ev)
     return false; 
 } 
  
+// [crispy] For fast polling.
+void G_FastResponder (void)
+{
+    if (newfastmouse)
+    {
+        mousex += fastmouse.data2;
+        mousey += fastmouse.data3;
+
+        newfastmouse = false;
+    }
+}
  
+// [crispy]
+void G_PrepTiccmd (void)
+{
+    const boolean strafe = gamekeydown[key_strafe] ||
+        mousebuttons[mousebstrafe] || joybuttons[joybstrafe];
+
+    if (mousex && !strafe)
+    {
+        localview.rawangle -= CalcMouseAngle(mousex);
+        basecmd.angleturn = CarryAngle(localview.rawangle);
+        localview.angle = (basecmd.angleturn << 16);
+        mousex = 0;
+    }
+/*
+    if (mousey && crispy->mouselook)
+    {
+        const double vert = CalcMouseVert(mousey);
+        basecmd.lookdir += mouse_y_invert ?
+                            CarryPitch(-vert): CarryPitch(vert);
+        mousey = 0;
+    }
+*/
+}
+
 // [crispy] re-read game parameters from command line
 static void G_ReadGameParms (void)
 {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -352,13 +352,6 @@ static short CarryAngle(double angle)
     return CarryError(angle, &prevcarry.angle, &carry.angle);
 }
 
-/*
-static short CarryPitch(double pitch)
-{
-    return CarryError(pitch, &prevcarry.pitch, &carry.pitch);
-}
-*/
-
 static int CarryMouseVert(double vert)
 {
     return CarryError(vert, &prevcarry.vert, &carry.vert);
@@ -410,8 +403,8 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     {
         // [JN] CRL - can't interpolate spectator.
         memset(cmd, 0, sizeof(ticcmd_t));
-        // [JN] CRL - do not count basecmd.angleturn for precise position
-        // of jumping to spectator camera position.
+        // [JN] CRL - reset basecmd.angleturn for exact
+        // position of jumping to the camera position.
         basecmd.angleturn = 0;
     }
 
@@ -790,10 +783,6 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     forward += CarryMouseVert(mousey);
     }
 
-/*
-    if (strafe && !cmd->angleturn)
-	side += CarryMouseSide(CalcMouseSide(mousex));
-*/
     if (strafe) 
 	side += mousex*2;
     else 
@@ -1371,8 +1360,8 @@ boolean G_Responder (event_t* ev)
 		 
       case ev_mouse: 
         SetMouseButtons(ev->data1);
-        mousex += ev->data2;
-        mousey += ev->data3;
+	mousex += ev->data2;
+	mousey += ev->data3;
 	return true;    // eat events 
  
       case ev_joystick: 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -425,6 +425,9 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     {
         // [JN] CRL - can't interpolate spectator.
         memset(cmd, 0, sizeof(ticcmd_t));
+        // [JN] CRL - do not count basecmd.angleturn for precise position
+        // of jumping to spectator camera position.
+        basecmd.angleturn = 0;
     }
 
 	// needed for net games
@@ -813,7 +816,16 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         if (!crl_spectating)
         cmd->angleturn += CarryMouseSide(CalcMouseSide(mousex));
         else
-        angle -= mousex*0x8;
+        {
+            if (crl_uncapped_fps)
+            {
+                angle -= CarryMouseSide(mousex);
+            }
+            else
+            {
+                angle -= mousex*0x8;
+            }
+        }
     }
 
     if (mousex == 0)

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -352,10 +352,12 @@ static short CarryAngle(double angle)
     return CarryError(angle, &prevcarry.angle, &carry.angle);
 }
 
+/*
 static short CarryPitch(double pitch)
 {
     return CarryError(pitch, &prevcarry.pitch, &carry.pitch);
 }
+*/
 
 static int CarryMouseVert(double vert)
 {
@@ -792,14 +794,14 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     forward += CarryMouseVert(CalcMouseVert(mousey));
     }
 
+/*
     if (strafe && !cmd->angleturn)
 	side += CarryMouseSide(CalcMouseSide(mousex));
-/*
+*/
     if (strafe) 
 	side += mousex*2;
     else 
-	cmd->angleturn -= mousex*0x8; 
-*/
+	cmd->angleturn += CarryMouseSide(CalcMouseSide(mousex));
 
     if (mousex == 0)
     {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -414,10 +414,18 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     int		side;
     ticcmd_t spect;
 
-    // [crispy] For fast polling.
-    G_PrepTiccmd();
-    memcpy(cmd, &basecmd, sizeof(*cmd));
-    memset(&basecmd, 0, sizeof(ticcmd_t));
+    if (!crl_spectating)
+    {
+        // [crispy] For fast polling.
+        G_PrepTiccmd();
+        memcpy(cmd, &basecmd, sizeof(*cmd));
+        memset(&basecmd, 0, sizeof(ticcmd_t));
+    }
+    else
+    {
+        // [JN] CRL - can't interpolate spectator.
+        memset(cmd, 0, sizeof(ticcmd_t));
+    }
 
 	// needed for net games
     cmd->consistancy = consistancy[consoleplayer][maketic%BACKUPTICS]; 
@@ -801,7 +809,12 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     if (strafe) 
 	side += mousex*2;
     else 
-	cmd->angleturn += CarryMouseSide(CalcMouseSide(mousex));
+    {
+        if (!crl_spectating)
+        cmd->angleturn += CarryMouseSide(CalcMouseSide(mousex));
+        else
+        angle -= mousex*0x8;
+    }
 
     if (mousex == 0)
     {

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -28,6 +28,8 @@
 
 extern boolean G_CheckDemoStatus (void);
 extern boolean G_Responder (event_t *ev);
+void G_FastResponder (void); // [crispy]
+void G_PrepTiccmd (void); // [crispy]
 extern fixed_t forwardmove[2];
 extern fixed_t sidemove[2];
 

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -155,6 +155,13 @@ void P_MovePlayer (player_t* player)
     // [JN] CRL - allow airborne controls while Arch-Vile's Fly as well.
     onground |= CRL_aircontrol;
 	
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.ticangle += localview.ticangleturn << 16;
+        localview.ticangleturn = 0;
+    }
+
     if (cmd->forwardmove && onground)
 	P_Thrust (player, player->mo->angle, cmd->forwardmove*2048);
     
@@ -275,6 +282,12 @@ void P_PlayerThink (player_t* player)
     player->mo->oldz = player->mo->z;
     player->mo->oldangle = player->mo->angle;
     player->oldviewz = player->viewz;
+
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.oldticangle = localview.ticangle;
+    }
 
     // [JN] Handle Spectator camera:
     if (crl_spectating)

--- a/src/doom/r_bsp.c
+++ b/src/doom/r_bsp.c
@@ -253,11 +253,13 @@ void R_MaybeInterpolateSector(sector_t* sector)
     {
         // Interpolate between current and last floor/ceiling position.
         if (sector->floorheight != sector->oldfloorheight)
-            sector->interpfloorheight = sector->oldfloorheight + FixedMul(sector->floorheight - sector->oldfloorheight, fractionaltic);
+            sector->interpfloorheight =
+                LerpFixed(sector->oldfloorheight, sector->floorheight);
         else
             sector->interpfloorheight = sector->floorheight;
         if (sector->ceilingheight != sector->oldceilingheight)
-            sector->interpceilingheight = sector->oldceilingheight + FixedMul(sector->ceilingheight - sector->oldceilingheight, fractionaltic);
+            sector->interpceilingheight =
+                LerpFixed(sector->oldceilingheight, sector->ceilingheight);
         else
             sector->interpceilingheight = sector->ceilingheight;
     }

--- a/src/doom/r_local.h
+++ b/src/doom/r_local.h
@@ -25,12 +25,11 @@
 
 #include "tables.h"
 #include "d_player.h"
-#include "i_video.h" // [crispy] fractionaltic
 #include "doomdef.h"
 #include "i_video.h"
 #include "v_patch.h"
 
-#include "crlcore.h" // [crispy] fractionaltic
+#include "crlcore.h"
 
 
 #define MAXVISSPRITES   128
@@ -479,8 +478,8 @@ extern fixed_t viewy;
 extern fixed_t viewz;
 
 extern angle_t   viewangle;
-extern localview_t      localview; // [crispy]
 extern player_t *viewplayer;
+extern localview_t localview; // [crispy]
 
 extern int      viewangletox[FINEANGLES/2];
 extern angle_t  xtoviewangle[SCREENWIDTH+1];

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -796,10 +796,10 @@ void R_SetupFrame (player_t* player)
         
         if (crl_uncapped_fps)
         {
-        	viewx = LerpFixed(CRL_camera_oldx, bx);
-        	viewy = LerpFixed(CRL_camera_oldy, by);
-        	viewz = LerpFixed(CRL_camera_oldz, bz);
-        	viewangle = LerpAngle(CRL_camera_oldang, ba);
+            viewx = LerpFixed(CRL_camera_oldx, bx);
+            viewy = LerpFixed(CRL_camera_oldy, by);
+            viewz = LerpFixed(CRL_camera_oldz, bz);
+            viewangle = LerpAngle(CRL_camera_oldang, ba);
         }
         else
         {
@@ -822,7 +822,7 @@ void R_SetupFrame (player_t* player)
             // Don't interpolate during a paused state
             realleveltime > oldleveltime)
         {
-        	const boolean use_localview = CheckLocalView(player);
+            const boolean use_localview = CheckLocalView(player);
 
             viewx = LerpFixed(player->mo->oldx, player->mo->x);
             viewy = LerpFixed(player->mo->oldy, player->mo->y);

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -463,7 +463,6 @@ fixed_t R_ScaleFromGlobalAngle (angle_t visangle)
 
 
 
-
 //
 // R_InitTextureMapping
 //
@@ -801,12 +800,6 @@ void R_SetupFrame (player_t* player)
         	viewy = LerpFixed(CRL_camera_oldy, by);
         	viewz = LerpFixed(CRL_camera_oldz, bz);
         	viewangle = LerpAngle(CRL_camera_oldang, ba);
-        	/*
-            viewx = CRL_camera_oldx + FixedMul(bx - CRL_camera_oldx, fractionaltic);
-            viewy = CRL_camera_oldy + FixedMul(by - CRL_camera_oldy, fractionaltic);
-            viewz = CRL_camera_oldz + FixedMul(bz - CRL_camera_oldz, fractionaltic);
-            viewangle = R_InterpolateAngle(CRL_camera_oldang, ba, fractionaltic);
-            */
         }
         else
         {
@@ -831,29 +824,22 @@ void R_SetupFrame (player_t* player)
         {
         	const boolean use_localview = CheckLocalView(player);
 
-        	viewx = LerpFixed(player->mo->oldx, player->mo->x);
-        	viewy = LerpFixed(player->mo->oldy, player->mo->y);
+            viewx = LerpFixed(player->mo->oldx, player->mo->x);
+            viewy = LerpFixed(player->mo->oldy, player->mo->y);
             viewz = LerpFixed(player->oldviewz, player->viewz);
 
-        if (use_localview)
-        {
-            viewangle = (player->mo->angle + localview.angle -
-                        localview.ticangle + LerpAngle(localview.oldticangle,
-                                                       localview.ticangle)) + viewangleoffset;
-        }
-        else
-        {
-            viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
-        }
-
-        	//viewangle = LerpAngle(player->mo->oldangle, player->mo->angle);
-        	/*
-            // Interpolate player camera from their old position to their current one.
-            viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-            viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-            viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
-            viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+            /*
+            if (use_localview)
+            {
+                viewangle = (player->mo->angle + localview.angle -
+                            localview.ticangle + LerpAngle(localview.oldticangle,
+                                                           localview.ticangle)) + viewangleoffset;
+            }
+            else
             */
+            {
+                viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+            }
         }
         else
         {

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -769,8 +769,8 @@ static inline boolean CheckLocalView(const player_t *player)
     player->playerstate != PST_DEAD &&
     // Don't use localview if the player just teleported.
     !player->mo->reactiontime &&
-    // Don't use localview if a demo is playing.
-    !demoplayback &&
+    // Don't use localview if a demo is playing or recording.
+    !demoplayback && !demorecording &&
     // Don't use localview during a netgame (single-player only).
     !netgame
   );

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -828,7 +828,6 @@ void R_SetupFrame (player_t* player)
             viewy = LerpFixed(player->mo->oldy, player->mo->y);
             viewz = LerpFixed(player->oldviewz, player->viewz);
 
-            /*
             if (use_localview)
             {
                 viewangle = (player->mo->angle + localview.angle -
@@ -836,7 +835,6 @@ void R_SetupFrame (player_t* player)
                                                            localview.ticangle)) + viewangleoffset;
             }
             else
-            */
             {
                 viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
             }

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -59,6 +59,7 @@ fixed_t			viewy;
 fixed_t			viewz;
 
 angle_t			viewangle;
+localview_t		localview; // [crispy]
 
 fixed_t			viewcos;
 fixed_t			viewsin;
@@ -459,26 +460,7 @@ fixed_t R_ScaleFromGlobalAngle (angle_t visangle)
     return scale;
 }
 
-// [AM] Interpolate between two angles.
-angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale)
-{
-    if (nangle == oangle)
-        return nangle;
-    else if (nangle > oangle)
-    {
-        if (nangle - oangle < ANG270)
-            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(scale));
-        else // Wrapped around
-            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(scale));
-    }
-    else // nangle < oangle
-    {
-        if (oangle - nangle < ANG270)
-            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(scale));
-        else // Wrapped around
-            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(scale));
-    }
-}
+
 
 
 
@@ -778,6 +760,23 @@ R_PointInSubsector
 }
 
 
+// [crispy]
+static inline boolean CheckLocalView(const player_t *player)
+{
+  return (
+    // Don't use localview if the player is spying.
+    player == &players[consoleplayer] &&
+    // Don't use localview if the player is dead.
+    player->playerstate != PST_DEAD &&
+    // Don't use localview if the player just teleported.
+    !player->mo->reactiontime &&
+    // Don't use localview if a demo is playing.
+    !demoplayback &&
+    // Don't use localview during a netgame (single-player only).
+    !netgame
+  );
+}
+
 
 //
 // R_SetupFrame
@@ -798,10 +797,16 @@ void R_SetupFrame (player_t* player)
         
         if (crl_uncapped_fps)
         {
+        	viewx = LerpFixed(CRL_camera_oldx, bx);
+        	viewy = LerpFixed(CRL_camera_oldy, by);
+        	viewz = LerpFixed(CRL_camera_oldz, bz);
+        	viewangle = LerpAngle(CRL_camera_oldang, ba);
+        	/*
             viewx = CRL_camera_oldx + FixedMul(bx - CRL_camera_oldx, fractionaltic);
             viewy = CRL_camera_oldy + FixedMul(by - CRL_camera_oldy, fractionaltic);
             viewz = CRL_camera_oldz + FixedMul(bz - CRL_camera_oldz, fractionaltic);
             viewangle = R_InterpolateAngle(CRL_camera_oldang, ba, fractionaltic);
+            */
         }
         else
         {
@@ -824,11 +829,31 @@ void R_SetupFrame (player_t* player)
             // Don't interpolate during a paused state
             realleveltime > oldleveltime)
         {
+        	const boolean use_localview = CheckLocalView(player);
+
+        	viewx = LerpFixed(player->mo->oldx, player->mo->x);
+        	viewy = LerpFixed(player->mo->oldy, player->mo->y);
+            viewz = LerpFixed(player->oldviewz, player->viewz);
+
+        if (use_localview)
+        {
+            viewangle = (player->mo->angle + localview.angle -
+                        localview.ticangle + LerpAngle(localview.oldticangle,
+                                                       localview.ticangle)) + viewangleoffset;
+        }
+        else
+        {
+            viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        }
+
+        	//viewangle = LerpAngle(player->mo->oldangle, player->mo->angle);
+        	/*
             // Interpolate player camera from their old position to their current one.
             viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
             viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
             viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
             viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+            */
         }
         else
         {

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -498,12 +498,6 @@ void R_ProjectSprite (mobj_t* thing)
         interpy = LerpFixed(thing->oldy, thing->y);
         interpz = LerpFixed(thing->oldz, thing->z);
         interpangle = LerpAngle(thing->oldangle, thing->angle);
-    	/*
-        interpx = thing->oldx + FixedMul(thing->x - thing->oldx, fractionaltic);
-        interpy = thing->oldy + FixedMul(thing->y - thing->oldy, fractionaltic);
-        interpz = thing->oldz + FixedMul(thing->z - thing->oldz, fractionaltic);
-        interpangle = R_InterpolateAngle(thing->oldangle, thing->angle, fractionaltic);
-        */
     }
     else
     {

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -494,10 +494,16 @@ void R_ProjectSprite (mobj_t* thing)
         // so their sprite won't get desynced with moving camera.
         (crl_freeze && thing->type == MT_PLAYER)))
     {
+        interpx = LerpFixed(thing->oldx, thing->x);
+        interpy = LerpFixed(thing->oldy, thing->y);
+        interpz = LerpFixed(thing->oldz, thing->z);
+        interpangle = LerpAngle(thing->oldangle, thing->angle);
+    	/*
         interpx = thing->oldx + FixedMul(thing->x - thing->oldx, fractionaltic);
         interpy = thing->oldy + FixedMul(thing->y - thing->oldy, fractionaltic);
         interpz = thing->oldz + FixedMul(thing->z - thing->oldz, fractionaltic);
         interpangle = R_InterpolateAngle(thing->oldangle, thing->angle, fractionaltic);
+        */
     }
     else
     {
@@ -787,9 +793,10 @@ void R_DrawPSprite (pspdef_t* psp)
         if (lump == oldlump && pspr_interp)
         {
             int deltax = vis->x2 - vis->x1;
-            vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
+            vis->x1 = LerpFixed(oldx1, vis->x1);
             vis->x2 = vis->x1 + deltax;
-            vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
+            vis->x2 = vis->x2 >= viewwidth ? viewwidth - 1 : vis->x2;
+            vis->texturemid = LerpFixed(oldtexturemid, vis->texturemid);
         }
         else
         {

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -109,6 +109,12 @@ int vanilla_keyboard_mapping = true;
 // by mouse_acceleration to increase the speed.
 float mouse_acceleration = 2.0;
 int mouse_threshold = 10;
+// [crispy]
+float mouse_acceleration_y = 1.0;
+int mouse_threshold_y = 0;
+int mouse_y_invert = 0;
+
+int runcentering = 1; // [crispy]
 
 // Translates the SDL key to a value of the type found in doomkeys.h
 static int TranslateKey(SDL_Keysym *sym)
@@ -428,14 +434,100 @@ void I_HandleMouseEvent(SDL_Event *sdlevent)
     }
 }
 
-static int AccelerateMouse(int val)
+// [crispy] Adjustable mouse accel threshold when running uncapped.
+static float x_threshold;
+static float y_threshold;
+
+// [crispy] Track the last gametic's worth of mouse movement in ring buffers.
+// Each element is a bin for the mouse movement recorded in that millisecond.
+// The running total is used to determine if mouse acceleration should be
+// applied.
+
+#define MOUSE_BUFFER_SIZE 32
+#define MOUSE_BUFFER_DEPTH_MS 28
+
+typedef struct
+{
+    int values[MOUSE_BUFFER_SIZE];
+    int head;
+    int tail;
+    int size;
+    int total;
+} mousebuffer_t;
+
+static mousebuffer_t mousex;
+static mousebuffer_t mousey;
+
+static void ResetMouseBuffer(mousebuffer_t *buf)
+{
+    buf->head = buf->tail = buf->size = buf->total = 0;
+}
+
+static void UpdateMouseBuffer(mousebuffer_t *buf, int value, int delta_ms)
+{
+    for (int i = 0; i < delta_ms; i++)
+    {
+        if (buf->size == MOUSE_BUFFER_DEPTH_MS)
+        {
+            buf->tail = (buf->tail + 1) & (MOUSE_BUFFER_SIZE - 1);
+            buf->total -= buf->values[buf->tail];
+        }
+        else
+        {
+            buf->size++;
+        }
+        buf->head = (buf->head + 1) & (MOUSE_BUFFER_SIZE - 1);
+        buf->values[buf->head] = 0;
+    }
+
+    buf->total += value;
+    buf->values[buf->head] += value;
+}
+
+static void UpdateMouseAccel(int x, int y)
+{
+    static uint64_t last_read;
+    const uint64_t current_read = I_GetTimeMS();
+    uint64_t delta_t;
+
+    delta_t = current_read - last_read;
+    last_read = current_read;
+
+    if (!crl_uncapped_fps)
+    {
+        x_threshold = mouse_threshold;
+        y_threshold = mouse_threshold_y;
+        mousex.total = x;
+        mousey.total = y;
+    }
+    else if (delta_t > MOUSE_BUFFER_DEPTH_MS)
+    {
+        ResetMouseBuffer(&mousex);
+        ResetMouseBuffer(&mousey);
+        UpdateMouseBuffer(&mousex, x, 1);
+        UpdateMouseBuffer(&mousey, y, 1);
+        x_threshold = mouse_threshold;
+        y_threshold = mouse_threshold_y;
+    }
+    else
+    {
+        UpdateMouseBuffer(&mousex, x, delta_t);
+        UpdateMouseBuffer(&mousey, y, delta_t);
+        x_threshold = mouse_threshold * delta_t * TICRATE / 1000.0;
+        y_threshold = mouse_threshold_y * delta_t * TICRATE / 1000.0;
+    }
+
+}
+
+// [crispy] Change to double
+double I_AccelerateMouse(int val)
 {
     if (val < 0)
-        return -AccelerateMouse(-val);
+        return -I_AccelerateMouse(-val);
 
-    if (val > mouse_threshold)
+    if (abs(mousex.total) > mouse_threshold)
     {
-        return (int)((val - mouse_threshold) * mouse_acceleration + mouse_threshold);
+        return (val - x_threshold) * mouse_acceleration + x_threshold;
     }
     else
     {
@@ -443,30 +535,20 @@ static int AccelerateMouse(int val)
     }
 }
 
-// [crispy] Distribute the mouse movement between the current tic and the next
-// based on how far we are into the current tic. Compensates for mouse sampling
-// jitter.
-static void SmoothMouse(int* x, int* y)
+// [crispy] Change to double
+double I_AccelerateMouseY(int val)
 {
-    static int x_remainder_old = 0;
-    static int y_remainder_old = 0;
-    int x_remainder, y_remainder;
-    fixed_t correction_factor;
-    fixed_t fractic;
+    if (val < 0)
+        return -I_AccelerateMouseY(-val);
 
-    *x += x_remainder_old;
-    *y += y_remainder_old;
-
-    fractic = I_GetFracRealTime();
-    correction_factor = FixedDiv(fractic, FRACUNIT + fractic);
-
-    x_remainder = FixedMul(*x, correction_factor);
-    *x -= x_remainder;
-    x_remainder_old = x_remainder;
-
-    y_remainder = FixedMul(*y, correction_factor);
-    *y -= y_remainder;
-    y_remainder_old = y_remainder;
+    if (abs(mousey.total) > mouse_threshold_y)
+    {
+        return (val - y_threshold) * mouse_acceleration_y + y_threshold;
+    }
+    else
+    {
+        return val;
+    }
 }
 
 //
@@ -480,21 +562,17 @@ void I_ReadMouse(void)
     event_t ev;
 
     SDL_GetRelativeMouseState(&x, &y);
-
-    if (crl_uncapped_fps)
-    {
-        SmoothMouse(&x, &y);
-    }
+    UpdateMouseAccel(x, y); // [crispy]
 
     if (x != 0 || y != 0) 
     {
         ev.type = ev_mouse;
         ev.data1 = mouse_button_state;
-        ev.data2 = AccelerateMouse(x);
+        ev.data2 = x;
 
         if (true || !novert) // [crispy] moved to src/*/g_game.c
         {
-            ev.data3 = -AccelerateMouse(y); // [crispy]
+            ev.data3 = -y; // [crispy]
         }
         else
         {
@@ -507,6 +585,29 @@ void I_ReadMouse(void)
     }
 }
 
+void I_ReadMouseUncapped(void)
+{
+    int x, y;
+
+    SDL_GetRelativeMouseState(&x, &y);
+    UpdateMouseAccel(x, y);
+
+    if (x != 0 || y != 0)
+    {
+        fastmouse.data2 = x;
+
+        if (true || !novert) // [crispy] moved to src/*/g_game.c
+        {
+            fastmouse.data3 = -y; // [crispy]
+        }
+        else
+        {
+            fastmouse.data3 = 0;
+        }
+
+        newfastmouse = true;
+    }
+}
 // Bind all variables controlling input options.
 void I_BindInputVariables(void)
 {

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -33,9 +33,20 @@ extern int SDL_mouseButton;
 
 extern float mouse_acceleration;
 extern int mouse_threshold;
+extern float mouse_acceleration_y; // [crispy]
+extern int mouse_threshold_y; // [crispy]
+extern int mouse_y_invert; // [crispy]
+//extern int novert; // [crispy]
+extern int runcentering; // [crispy]
 
+// [crispy]
+double I_AccelerateMouse(int val);
+double I_AccelerateMouseY(int val);
+
+void I_BindStrifeInputVariables(void); // [crispy]
 void I_BindInputVariables(void);
 void I_ReadMouse(void);
+void I_ReadMouseUncapped(void); // [crispy]
 
 // I_StartTextInput begins text input, activating the on-screen keyboard
 // (if one is used). The caller indicates that any entered text will be

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -591,6 +591,18 @@ void I_StartTic (void)
     }
 }
 
+void I_StartDisplay(void) // [crispy]
+{
+    // [AM] Figure out how far into the current tic we're in as a fixed_t.
+    fractionaltic = I_GetFracRealTime();
+
+    SDL_PumpEvents();
+
+    if (usemouse && !nomouse && window_focused)
+    {
+        I_ReadMouseUncapped();
+    }
+}
 static void UpdateGrab(void)
 {
     static boolean currently_grabbed = false;
@@ -949,9 +961,6 @@ void I_FinishUpdate (void)
                 }
             }
         }
-
-        // [AM] Figure out how far into the current tic we're in as a fixed_t.
-        fractionaltic = I_GetFracRealTime();
     }
 
     // Restore background and undo the disk indicator, if it was drawn.

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -82,6 +82,8 @@ void I_StartFrame (void);
 
 void I_StartTic (void);
 
+void I_StartDisplay (void); // [crispy]
+
 // Enable the loading disk image displayed when reading from disk.
 
 void I_EnableLoadingDisk(int xoffs, int yoffs);


### PR DESCRIPTION
Almost a carbon copy of Michael's implementation for Crispy Doom, except no fast polling for spectator. Things becomes a bit more complicated by cobining render+controls, but at leasts all spectator functions are happy with new interpolation.

It's a godsend, the difference is noticable even on 120 Hz monitor!